### PR TITLE
llm-wiki: add git-backed wiki extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ pi install git:github.com/fosskar/pi-pack
 
 Pi records the package in `~/.pi/agent/settings.json`. Use `pi config` to enable or disable individual resources.
 
+The `llm-wiki` extension requires Git in `PATH`. Configure its local clone before use:
+
+```bash
+export LLM_WIKI_PATH="$HOME/Projects/llm-wiki"
+export LLM_WIKI_REMOTE="git@github.com:owner/llm-wiki.git" # needed to create or verify the clone
+export LLM_WIKI_BRANCH="main"                              # default: main
+```
+
 The `sediment-memory` extension also requires Sediment in `PATH`. Nix users without Home Manager can install it separately:
 
 ```bash
@@ -199,6 +207,18 @@ Home Manager can deploy one skill for another agent:
 </details>
 
 <details>
+<summary><strong>llm-wiki</strong> - synchronize and update a Git-backed LLM wiki</summary>
+
+- **Source:** [`extensions/llm-wiki/`](extensions/llm-wiki/)
+- **Tool:** `llm_wiki`
+- **Actions:** `status`, `search`, `read`, and `apply`
+- **Commands:** `/wiki-capture`, `/wiki-query`, `/wiki-observe`, `/wiki-lint`, and `/wiki-status`
+- **Requirement:** `git` in `PATH`
+- **Use:** Safely operate an existing Git-backed wiki without GitHub APIs.
+
+</details>
+
+<details>
 <summary><strong>sediment-memory</strong> - extract and recall long-term memories</summary>
 
 - **Source:** [`extensions/sediment-memory/index.ts`](extensions/sediment-memory/index.ts)
@@ -256,6 +276,8 @@ outputs:
 ## Security
 
 extensions execute code in the agent process. review them before installing from git.
+
+`llm-wiki` commits and pushes successful mutation operations. It stops on dirty state, divergence, stale content, validation errors, locks, and push rejection.
 
 skills can instruct an agent to run commands. review them before enabling in unattended services.
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Home Manager can deploy one skill for another agent:
 - **Requirement:** `git` in `PATH`
 - **Use:** Safely operate an existing Git-backed wiki without GitHub APIs.
 
+The extension embeds the Karpathy LLM Wiki pattern and the OKF v0.2 document baseline. It discovers and preserves the connected repository layout. It does not require `raw/`, `wiki/`, `SPEC.md`, or `AGENTS.md`. Each `apply` file declares its `source`, `concept`, `index`, or `log` role.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ pi install git:github.com/fosskar/pi-pack
 
 Pi records the package in `~/.pi/agent/settings.json`. Use `pi config` to enable or disable individual resources.
 
-The `llm-wiki` extension requires Git in `PATH`. Configure its local clone before use:
+The `llm-wiki` extension requires Git in `PATH`. It searches the working directory and its parents for a Git repository named `llm-wiki` with `raw/` and `wiki/`. Use these optional overrides when automatic discovery is not sufficient:
 
 ```bash
 export LLM_WIKI_PATH="$HOME/Projects/llm-wiki"
-export LLM_WIKI_REMOTE="git@github.com:owner/llm-wiki.git" # needed to create or verify the clone
+export LLM_WIKI_REMOTE="git@github.com:owner/llm-wiki.git" # create or verify the clone
 export LLM_WIKI_BRANCH="main"                              # default: main
 ```
 
@@ -216,7 +216,7 @@ Home Manager can deploy one skill for another agent:
 - **Requirement:** `git` in `PATH`
 - **Use:** Safely operate an existing Git-backed wiki without GitHub APIs.
 
-The extension embeds the Karpathy LLM Wiki pattern and the OKF v0.2 document baseline. It discovers and preserves the connected repository layout. It does not require `raw/`, `wiki/`, `SPEC.md`, or `AGENTS.md`. Each `apply` file declares its `source`, `concept`, `index`, or `log` role.
+The extension embeds the Karpathy LLM Wiki pattern and the OKF v0.2 document baseline. It requires a Git repository named `llm-wiki` with top-level `raw/` and `wiki/` directories. `SPEC.md`, `AGENTS.md`, and other supported schema files are optional. The extension reports each available schema file for the agent to read before semantic work.
 
 </details>
 

--- a/extensions/llm-wiki/README.md
+++ b/extensions/llm-wiki/README.md
@@ -1,0 +1,105 @@
+# llm-wiki
+
+Safely operate an existing Git-backed LLM wiki through Pi.
+
+The extension embeds the [LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) and the [Open Knowledge Format v0.2 baseline](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md). Repository guidance can add conventions, but it is not required.
+
+## Repository contract
+
+The repository must:
+
+- Be named `llm-wiki`.
+- Be a Git repository.
+- Contain a top-level `raw/` directory.
+- Contain a top-level `wiki/` directory.
+- Have a configured upstream branch.
+
+`raw/` contains immutable source material. `wiki/` contains derived knowledge.
+
+The extension does not use or create a `.llm-wiki/` directory.
+
+## Discovery
+
+For each directory from the Pi working directory to the filesystem root, the extension checks:
+
+1. The directory itself.
+2. Its `llm-wiki/` child.
+
+The extension stops when discovery finds no repository or several repositories.
+
+Use `LLM_WIKI_PATH` to select a repository explicitly:
+
+```bash
+export LLM_WIKI_PATH="$HOME/Projects/llm-wiki"
+```
+
+Optional settings:
+
+```bash
+export LLM_WIKI_BRANCH="main"
+export LLM_WIKI_REMOTE="git@github.com:owner/llm-wiki.git"
+```
+
+`LLM_WIKI_BRANCH` defaults to `main`. `LLM_WIKI_REMOTE` is required when the extension must create the clone. When set for an existing clone, it also verifies the remote URL.
+
+## Repository guidance
+
+The `status` action reports these root files when they exist:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `SPEC.md`
+- `WIKI_SCHEMA.md`
+- `llm-wiki.md`
+
+The agent must read every reported file before semantic work. These files can define repository-specific page types, layout, provenance, and workflows. They cannot weaken the extension's Git safety rules.
+
+## Tool actions
+
+The extension registers one `llm_wiki` tool:
+
+- `status` synchronizes the clone and reports its commit and guidance files.
+- `search` performs bounded fixed-string search.
+- `read` reads bounded text files and returns their SHA-256 hashes.
+- `apply` validates, commits, and pushes one complete semantic operation.
+
+Every `apply` file has one role:
+
+| Role      | Required location | Rules                                                        |
+| --------- | ----------------- | ------------------------------------------------------------ |
+| `source`  | `raw/`            | New immutable source material. Existing files cannot change. |
+| `concept` | `wiki/`           | Markdown with OKF frontmatter and a non-empty `type`.        |
+| `index`   | `wiki/`           | Markdown named `index.md`.                                   |
+| `log`     | `wiki/`           | Markdown named `log.md`.                                     |
+| `schema`  | Repository root   | A supported repository guidance file.                        |
+
+An update to an existing writable file requires the SHA-256 hash returned by `read`. The extension rejects stale hashes. `apply` accepts text content only.
+
+## Git transaction
+
+Before each operation, the extension:
+
+1. Takes an exclusive repository lock.
+2. Stops if the clone is dirty.
+3. Fetches the configured remote.
+4. Stops on divergence.
+5. Fast-forwards the local branch.
+
+For a mutation, it then:
+
+1. Creates a temporary Git worktree.
+2. Applies the complete file set.
+3. Validates paths, roles, hashes, frontmatter, and the staged diff.
+4. Commits with Git hooks disabled.
+5. Pushes without force.
+6. Reconciles the local clone.
+
+The extension never stashes, rebases, merges divergence, resolves conflicts, or force-pushes.
+
+## Commands
+
+- `/wiki-capture <source>` captures and ingests one source.
+- `/wiki-query <question>` answers from the wiki without mutation.
+- `/wiki-observe <fact>` preserves a user-stated durable fact.
+- `/wiki-lint` inspects the wiki without mutation.
+- `/wiki-status` synchronizes and reports repository status.

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -1,0 +1,772 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { randomUUID, createHash } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+
+const MAX_READ_FILES = 20;
+const MAX_READ_BYTES = 50 * 1024;
+const MAX_SEARCH_BYTES = 50 * 1024;
+const MAX_APPLY_FILES = 32;
+const MAX_APPLY_BYTES = 512 * 1024;
+
+export interface GitResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+  killed?: boolean;
+}
+
+export type GitRunner = (
+  args: string[],
+  options: { cwd?: string; signal?: AbortSignal; timeout?: number },
+) => Promise<GitResult>;
+
+export interface WikiConfig {
+  path: string;
+  remote?: string;
+  branch: string;
+}
+
+export interface WikiChange {
+  path: string;
+  content: string;
+  expected_sha256?: string;
+}
+
+function textResult(text: string, details: Record<string, unknown> = {}) {
+  return { content: [{ type: "text" as const, text }], details };
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function truncate(text: string, limit: number): string {
+  if (Buffer.byteLength(text) <= limit) return text;
+  let end = text.length;
+  while (end > 0 && Buffer.byteLength(text.slice(0, end)) > limit) end -= 1024;
+  return `${text.slice(0, Math.max(0, end))}\n\n[Output truncated at ${limit} bytes.]`;
+}
+
+function validateRelativePath(path: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  if (
+    !normalized ||
+    isAbsolute(normalized) ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../") ||
+    normalized === ".git" ||
+    normalized.startsWith(".git/") ||
+    normalized.includes("\0")
+  ) {
+    throw new Error(`Invalid wiki path: ${path}`);
+  }
+  return normalized.replace(/^\.\//, "");
+}
+
+async function canonicalizePath(path: string): Promise<string> {
+  let current = path;
+  const missing: string[] = [];
+  while (true) {
+    try {
+      return join(await realpath(current), ...missing.reverse());
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = dirname(current);
+      if (parent === current) throw error;
+      missing.push(basename(current));
+      current = parent;
+    }
+  }
+}
+
+async function assertNoSymlinkPath(root: string, path: string): Promise<void> {
+  const target = resolve(root, path);
+  const relation = relative(root, target);
+  if (relation.startsWith(`..${sep}`) || isAbsolute(relation)) {
+    throw new Error(`Wiki path escapes the clone: ${path}`);
+  }
+
+  let current = root;
+  for (const part of relation.split(sep).filter(Boolean)) {
+    current = join(current, part);
+    try {
+      if ((await lstat(current)).isSymbolicLink()) {
+        throw new Error(`Wiki path crosses a symbolic link: ${path}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+  }
+}
+
+function configFromEnvironment(): WikiConfig {
+  const configuredPath = process.env.LLM_WIKI_PATH;
+  if (!configuredPath) {
+    throw new Error(
+      "LLM_WIKI_PATH is not set. Set it to the local wiki clone path. " +
+        "Set LLM_WIKI_REMOTE too when the extension must create the clone.",
+    );
+  }
+  return {
+    path: resolve(configuredPath.replace(/^~(?=$|\/)/, homedir())),
+    remote: process.env.LLM_WIKI_REMOTE,
+    branch: process.env.LLM_WIKI_BRANCH || "main",
+  };
+}
+
+export class GitWikiRepository {
+  constructor(
+    private readonly config: WikiConfig,
+    private readonly runGit: GitRunner,
+  ) {}
+
+  async status(signal?: AbortSignal): Promise<Record<string, unknown>> {
+    return this.withLock(async () => {
+      await this.ensureClone(signal);
+      const commit = await this.synchronize(signal);
+      const upstream = await this.gitText(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        this.config.path,
+        signal,
+      );
+      return {
+        path: this.config.path,
+        branch: this.config.branch,
+        upstream,
+        commit,
+      };
+    });
+  }
+
+  async read(paths: string[], signal?: AbortSignal) {
+    if (paths.length === 0 || paths.length > MAX_READ_FILES) {
+      throw new Error(`read requires 1-${MAX_READ_FILES} paths`);
+    }
+    return this.withLock(async () => {
+      await this.ensureClone(signal);
+      const commit = await this.synchronize(signal);
+      const files = [];
+      let bytes = 0;
+      for (const input of paths) {
+        const path = validateRelativePath(input);
+        await assertNoSymlinkPath(this.config.path, path);
+        const content = await readFile(join(this.config.path, path), "utf8");
+        bytes += Buffer.byteLength(content);
+        if (bytes > MAX_READ_BYTES) {
+          throw new Error(
+            `read result exceeds ${MAX_READ_BYTES} bytes; request fewer files`,
+          );
+        }
+        files.push({ path, sha256: sha256(content), content });
+      }
+      return { commit, files };
+    });
+  }
+
+  async search(
+    query: string,
+    paths: string[] | undefined,
+    signal?: AbortSignal,
+  ) {
+    if (!query.trim()) throw new Error("search requires a non-empty query");
+    return this.withLock(async () => {
+      await this.ensureClone(signal);
+      const commit = await this.synchronize(signal);
+      const pathspecs = (paths ?? ["wiki", "raw", "AGENTS.md"]).map(
+        validateRelativePath,
+      );
+      const result = await this.runGit(
+        ["grep", "-Fni", "--", query, ...pathspecs],
+        { cwd: this.config.path, signal, timeout: 15_000 },
+      );
+      if (result.killed) throw new Error("git grep was cancelled or timed out");
+      if (result.code !== 0 && result.code !== 1) {
+        throw new Error(`git grep failed: ${result.stderr.trim()}`);
+      }
+      return {
+        commit,
+        matches: truncate(result.stdout.trim(), MAX_SEARCH_BYTES),
+      };
+    });
+  }
+
+  async apply(
+    operation: string,
+    message: string,
+    changes: WikiChange[],
+    signal?: AbortSignal,
+  ) {
+    this.validateApplyInput(operation, message, changes);
+    return this.withLock(async () => {
+      await this.ensureClone(signal);
+      const baseCommit = await this.synchronize(signal);
+      const worktree = await mkdtemp(join(tmpdir(), "pi-llm-wiki-"));
+      let publishedCommit: string | undefined;
+
+      try {
+        await this.git(
+          ["worktree", "add", "--detach", worktree, baseCommit],
+          this.config.path,
+          signal,
+        );
+        for (const change of changes) await this.writeChange(worktree, change);
+
+        const changedPaths = changes.map((change) =>
+          validateRelativePath(change.path),
+        );
+        await this.git(["add", "--", ...changedPaths], worktree, signal);
+        const staged = await this.gitText(
+          ["diff", "--cached", "--name-only", "--diff-filter=ACM"],
+          worktree,
+          signal,
+        );
+        const actualPaths = staged.split("\n").filter(Boolean).sort();
+        const expectedPaths = [...new Set(changedPaths)].sort();
+        if (JSON.stringify(actualPaths) !== JSON.stringify(expectedPaths)) {
+          throw new Error(
+            "The staged change set does not match the requested wiki files",
+          );
+        }
+
+        await this.validateWorktree(worktree, actualPaths, signal);
+        await this.git(
+          ["-c", "core.hooksPath=/dev/null", "commit", "-m", message],
+          worktree,
+          signal,
+        );
+        publishedCommit = await this.gitText(
+          ["rev-parse", "HEAD"],
+          worktree,
+          signal,
+        );
+        const committedPaths = (
+          await this.gitText(
+            [
+              "diff-tree",
+              "--no-commit-id",
+              "--name-only",
+              "-r",
+              publishedCommit,
+            ],
+            worktree,
+            signal,
+          )
+        )
+          .split("\n")
+          .filter(Boolean)
+          .sort();
+        if (JSON.stringify(committedPaths) !== JSON.stringify(expectedPaths)) {
+          throw new Error(
+            "The committed change set does not match the requested wiki files",
+          );
+        }
+
+        const upstream = await this.upstream(this.config.path, signal);
+        await this.git(
+          [
+            "push",
+            upstream.remote,
+            `${publishedCommit}:refs/heads/${upstream.branch}`,
+          ],
+          worktree,
+          signal,
+          60_000,
+        );
+
+        let reconciliationWarning: string | undefined;
+        try {
+          await this.git(
+            ["fetch", upstream.remote, upstream.branch],
+            this.config.path,
+          );
+          await this.git(
+            ["merge", "--ff-only", publishedCommit],
+            this.config.path,
+          );
+        } catch (error) {
+          reconciliationWarning =
+            "The push succeeded, but the local clone was not advanced: " +
+            (error instanceof Error ? error.message : String(error));
+        }
+
+        return {
+          operation,
+          baseCommit,
+          commit: publishedCommit,
+          changedPaths: actualPaths,
+          reconciliationWarning,
+        };
+      } finally {
+        try {
+          const removal = await this.runGit(
+            ["worktree", "remove", "--force", worktree],
+            { cwd: this.config.path, timeout: 15_000 },
+          );
+          if (removal.code !== 0) {
+            await this.runGit(["worktree", "prune"], {
+              cwd: this.config.path,
+              timeout: 15_000,
+            });
+          }
+          await rm(worktree, { recursive: true, force: true });
+        } catch (error) {
+          console.error("llm-wiki: failed to remove temporary worktree", error);
+        }
+      }
+    });
+  }
+
+  private validateApplyInput(
+    operation: string,
+    message: string,
+    changes: WikiChange[],
+  ): void {
+    if (!operation.trim()) throw new Error("apply requires an operation name");
+    if (!message.trim() || message.includes("\n") || message.length > 72) {
+      throw new Error(
+        "apply message must be one non-empty line of at most 72 characters",
+      );
+    }
+    if (changes.length === 0 || changes.length > MAX_APPLY_FILES) {
+      throw new Error(`apply requires 1-${MAX_APPLY_FILES} files`);
+    }
+    const paths = changes.map((change) => validateRelativePath(change.path));
+    if (new Set(paths).size !== paths.length)
+      throw new Error("apply contains duplicate paths");
+    if (
+      paths.some(
+        (path) => !path.startsWith("raw/") && !path.startsWith("wiki/"),
+      )
+    ) {
+      throw new Error("apply can change only raw/ and wiki/ paths");
+    }
+    const bytes = changes.reduce(
+      (sum, change) => sum + Buffer.byteLength(change.content),
+      0,
+    );
+    if (bytes > MAX_APPLY_BYTES) {
+      throw new Error(`apply content exceeds ${MAX_APPLY_BYTES} bytes`);
+    }
+  }
+
+  private async writeChange(
+    worktree: string,
+    change: WikiChange,
+  ): Promise<void> {
+    const path = validateRelativePath(change.path);
+    await assertNoSymlinkPath(worktree, path);
+    const target = join(worktree, path);
+    let current: string | undefined;
+    try {
+      current = await readFile(target, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+
+    if (current === undefined) {
+      if (change.expected_sha256 !== undefined) {
+        throw new Error(`Expected existing file is missing: ${path}`);
+      }
+    } else {
+      if (path.startsWith("raw/"))
+        throw new Error(`Raw source is immutable: ${path}`);
+      if (!change.expected_sha256) {
+        throw new Error(`Existing file requires expected_sha256: ${path}`);
+      }
+      if (sha256(current) !== change.expected_sha256) {
+        throw new Error(`File changed since it was read: ${path}`);
+      }
+    }
+
+    await mkdir(dirname(target), { recursive: true });
+    const temporary = join(
+      dirname(target),
+      `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+    );
+    const handle = await open(
+      temporary,
+      constants.O_CREAT |
+        constants.O_EXCL |
+        constants.O_WRONLY |
+        (constants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    try {
+      await handle.writeFile(change.content, "utf8");
+    } finally {
+      await handle.close();
+    }
+    await rename(temporary, target);
+    if (!(await lstat(target)).isFile()) {
+      throw new Error(`Wiki path is not a regular file: ${path}`);
+    }
+  }
+
+  private async validateWorktree(
+    worktree: string,
+    changedPaths: string[],
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await lstat(join(worktree, "AGENTS.md"));
+    for (const path of changedPaths) {
+      if (!path.startsWith("wiki/") || !path.endsWith(".md")) continue;
+      const name = basename(path).toLowerCase();
+      if (name === "index.md" || name === "log.md") continue;
+      const content = await readFile(join(worktree, path), "utf8");
+      const closing = content.indexOf("\n---\n", 4);
+      const frontmatter = closing < 0 ? "" : content.slice(4, closing);
+      const type = frontmatter.match(/^type:\s*(.+)$/m)?.[1]?.trim();
+      if (!type || type.startsWith("#")) {
+        throw new Error(
+          `Wiki page requires valid frontmatter with type: ${path}`,
+        );
+      }
+    }
+    await this.git(["diff", "--cached", "--check"], worktree, signal);
+  }
+
+  private async ensureClone(signal?: AbortSignal): Promise<void> {
+    try {
+      await lstat(join(this.config.path, ".git"));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      if (!this.config.remote) {
+        throw new Error(
+          `Wiki clone does not exist and LLM_WIKI_REMOTE is not set: ${this.config.path}`,
+        );
+      }
+      await mkdir(dirname(this.config.path), { recursive: true });
+      await this.git(
+        [
+          "clone",
+          "--branch",
+          this.config.branch,
+          "--single-branch",
+          this.config.remote,
+          this.config.path,
+        ],
+        dirname(this.config.path),
+        signal,
+        60_000,
+      );
+    }
+    await lstat(join(this.config.path, "AGENTS.md"));
+  }
+
+  private async synchronize(signal?: AbortSignal): Promise<string> {
+    const status = await this.gitText(
+      ["status", "--porcelain=v1", "--untracked-files=all"],
+      this.config.path,
+      signal,
+    );
+    if (status)
+      throw new Error(
+        "Wiki clone has uncommitted changes; resolve them before continuing",
+      );
+
+    const branch = await this.gitText(
+      ["branch", "--show-current"],
+      this.config.path,
+      signal,
+    );
+    if (branch !== this.config.branch) {
+      throw new Error(
+        `Wiki clone is on ${branch || "detached HEAD"}; expected ${this.config.branch}`,
+      );
+    }
+
+    const upstream = await this.upstream(this.config.path, signal);
+    if (this.config.remote) {
+      const actualRemote = await this.gitText(
+        ["remote", "get-url", upstream.remote],
+        this.config.path,
+        signal,
+      );
+      if (actualRemote !== this.config.remote) {
+        throw new Error(
+          `Wiki remote mismatch: expected ${this.config.remote}, got ${actualRemote}`,
+        );
+      }
+    }
+
+    await this.git(
+      ["fetch", "--prune", upstream.remote, upstream.branch],
+      this.config.path,
+      signal,
+      60_000,
+    );
+    const local = await this.gitText(
+      ["rev-parse", "HEAD"],
+      this.config.path,
+      signal,
+    );
+    const remote = await this.gitText(
+      ["rev-parse", `refs/remotes/${upstream.remote}/${upstream.branch}`],
+      this.config.path,
+      signal,
+    );
+    if (local !== remote) {
+      const ancestor = await this.runGit(
+        ["merge-base", "--is-ancestor", local, remote],
+        {
+          cwd: this.config.path,
+          signal,
+          timeout: 15_000,
+        },
+      );
+      if (ancestor.code !== 0) {
+        throw new Error(
+          "Wiki clone is ahead of or diverged from its upstream branch",
+        );
+      }
+      await this.git(["merge", "--ff-only", remote], this.config.path, signal);
+    }
+    return this.gitText(["rev-parse", "HEAD"], this.config.path, signal);
+  }
+
+  private async upstream(
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<{ remote: string; branch: string }> {
+    const value = await this.gitText(
+      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+      cwd,
+      signal,
+    );
+    const separator = value.indexOf("/");
+    if (separator <= 0 || separator === value.length - 1) {
+      throw new Error(`Unsupported wiki upstream: ${value}`);
+    }
+    return {
+      remote: value.slice(0, separator),
+      branch: value.slice(separator + 1),
+    };
+  }
+
+  private async git(
+    args: string[],
+    cwd: string,
+    signal?: AbortSignal,
+    timeout = 30_000,
+  ): Promise<GitResult> {
+    const result = await this.runGit(args, { cwd, signal, timeout });
+    if (result.killed)
+      throw new Error(`git ${args[0]} was cancelled or timed out`);
+    if (result.code !== 0) {
+      const detail = truncate(
+        result.stderr.trim() || result.stdout.trim(),
+        MAX_READ_BYTES,
+      );
+      throw new Error(`git ${args[0]} failed: ${detail}`);
+    }
+    return result;
+  }
+
+  private async gitText(
+    args: string[],
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    return (await this.git(args, cwd, signal)).stdout.trim();
+  }
+
+  private async withLock<T>(work: () => Promise<T>): Promise<T> {
+    const canonicalPath = await canonicalizePath(this.config.path);
+    const lockPath = `${canonicalPath}.llm-wiki-lock`;
+    await mkdir(dirname(lockPath), { recursive: true });
+    try {
+      await mkdir(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new Error(
+          `Another wiki operation holds the lock: ${lockPath}. Remove it manually only after verifying that no operation is running.`,
+        );
+      }
+      throw error;
+    }
+    try {
+      await writeFile(
+        join(lockPath, "owner.json"),
+        `${JSON.stringify({ pid: process.pid, started: new Date().toISOString() })}\n`,
+      );
+      return await work();
+    } finally {
+      try {
+        await rm(lockPath, { recursive: true });
+      } catch (error) {
+        console.error("llm-wiki: failed to remove operation lock", error);
+      }
+    }
+  }
+}
+
+export default function llmWikiExtension(pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "llm_wiki",
+    label: "LLM Wiki",
+    description:
+      "Synchronize, search, read, or atomically update a Git-backed LLM wiki. " +
+      "Mutations validate, commit, and push one complete operation. Output is limited to 50KB.",
+    promptSnippet: "Read and update the configured Git-backed LLM wiki",
+    promptGuidelines: [
+      "Use llm_wiki when the user asks to capture, ingest, query, or lint wiki knowledge, or to preserve a durable personal fact.",
+      "Use llm_wiki for wiki repository access instead of direct Git commands or direct file mutation.",
+      "Read the repository AGENTS.md with llm_wiki before an apply action and follow it as the semantic authority.",
+      "Submit every new or changed file for one complete semantic operation in one llm_wiki apply action.",
+      "Preserve only non-sensitive personal facts stated by the user; never store secrets or inferred sensitive facts.",
+    ],
+    parameters: Type.Object({
+      action: StringEnum(["status", "search", "read", "apply"] as const),
+      query: Type.Optional(
+        Type.String({ description: "Fixed-string search query" }),
+      ),
+      paths: Type.Optional(
+        Type.Array(Type.String(), { maxItems: MAX_READ_FILES }),
+      ),
+      operation: Type.Optional(
+        StringEnum([
+          "capture",
+          "ingest",
+          "observation",
+          "query-note",
+          "lint-fix",
+        ] as const),
+      ),
+      message: Type.Optional(Type.String({ maxLength: 72 })),
+      files: Type.Optional(
+        Type.Array(
+          Type.Object({
+            path: Type.String(),
+            content: Type.String(),
+            expected_sha256: Type.Optional(Type.String()),
+          }),
+          { maxItems: MAX_APPLY_FILES },
+        ),
+      ),
+    }),
+    async execute(_toolCallId, params, signal) {
+      const config = configFromEnvironment();
+      const repository = new GitWikiRepository(config, (args, options) =>
+        pi.exec("git", args, options),
+      );
+
+      if (params.action === "status") {
+        const status = await repository.status(signal);
+        return textResult(
+          `Wiki synchronized at ${status.commit}\nPath: ${status.path}\nUpstream: ${status.upstream}`,
+          status,
+        );
+      }
+      if (params.action === "search") {
+        const result = await repository.search(
+          params.query ?? "",
+          params.paths,
+          signal,
+        );
+        return textResult(result.matches || "No matches found.", result);
+      }
+      if (params.action === "read") {
+        const result = await repository.read(params.paths ?? [], signal);
+        const rendered = result.files
+          .map(
+            (file) =>
+              `## ${file.path}\nsha256: ${file.sha256}\n\n${file.content}`,
+          )
+          .join("\n\n");
+        return textResult(rendered, result);
+      }
+      if (params.action === "apply") {
+        const result = await repository.apply(
+          params.operation ?? "",
+          params.message ?? "",
+          params.files ?? [],
+          signal,
+        );
+        const warning = result.reconciliationWarning
+          ? `\nWarning: ${result.reconciliationWarning}`
+          : "";
+        return textResult(
+          `Wiki operation pushed as ${result.commit}\nChanged: ${result.changedPaths.join(", ")}${warning}`,
+          result,
+        );
+      }
+      throw new Error(`Unsupported llm_wiki action: ${params.action}`);
+    },
+  });
+
+  const registerWorkflowCommand = (
+    name: string,
+    description: string,
+    instruction: (args: string) => string,
+    requiresArgument = true,
+  ) => {
+    pi.registerCommand(name, {
+      description,
+      handler: async (args, ctx) => {
+        const value = (args ?? "").trim();
+        if (requiresArgument && !value) {
+          if (ctx.hasUI)
+            ctx.ui.notify(`/${name} requires an argument`, "error");
+          return;
+        }
+        pi.sendUserMessage(instruction(value));
+      },
+    });
+  };
+
+  registerWorkflowCommand(
+    "wiki-capture",
+    "Capture and ingest a source into the Git-backed LLM wiki",
+    (source) =>
+      `Capture and ingest this source into the LLM wiki: ${source}\nUse llm_wiki only for repository access. Read AGENTS.md first. Submit the complete operation with one apply action.`,
+  );
+  registerWorkflowCommand(
+    "wiki-query",
+    "Answer a question from the Git-backed LLM wiki",
+    (question) =>
+      `Answer this question from the LLM wiki: ${question}\nUse llm_wiki to read AGENTS.md, search, and read the supporting pages. Keep the query read-only unless I explicitly request a filed note.`,
+  );
+  registerWorkflowCommand(
+    "wiki-observe",
+    "Preserve a durable personal fact in the Git-backed LLM wiki",
+    (observation) =>
+      `Preserve this user-stated observation in the LLM wiki: ${observation}\nUse llm_wiki only for repository access. Read AGENTS.md first. Do not infer or store sensitive facts. Submit the complete operation with one observation apply action.`,
+  );
+  registerWorkflowCommand(
+    "wiki-lint",
+    "Inspect the Git-backed LLM wiki without changing it",
+    () =>
+      "Lint the LLM wiki. Use llm_wiki to read AGENTS.md and inspect the complete relevant indexes. Report findings only. Do not apply fixes.",
+    false,
+  );
+  registerWorkflowCommand(
+    "wiki-status",
+    "Synchronize and show the Git-backed LLM wiki status",
+    () => "Call llm_wiki with the status action and report the result.",
+    false,
+  );
+}

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -30,6 +30,13 @@ const MAX_READ_BYTES = 50 * 1024;
 const MAX_SEARCH_BYTES = 50 * 1024;
 const MAX_APPLY_FILES = 32;
 const MAX_APPLY_BYTES = 512 * 1024;
+const GUIDANCE_FILES = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "SPEC.md",
+  "WIKI_SCHEMA.md",
+  "llm-wiki.md",
+] as const;
 
 export interface GitResult {
   stdout: string;
@@ -49,7 +56,7 @@ export interface WikiConfig {
   branch: string;
 }
 
-export type WikiFileRole = "source" | "concept" | "index" | "log";
+export type WikiFileRole = "source" | "concept" | "index" | "log" | "schema";
 
 export interface WikiChange {
   path: string;
@@ -126,16 +133,59 @@ async function assertNoSymlinkPath(root: string, path: string): Promise<void> {
   }
 }
 
-function configFromEnvironment(): WikiConfig {
-  const configuredPath = process.env.LLM_WIKI_PATH;
-  if (!configuredPath) {
+async function isWikiRepository(path: string): Promise<boolean> {
+  try {
+    const git = await lstat(join(path, ".git"));
+    return (
+      basename(path) === "llm-wiki" &&
+      (git.isDirectory() || git.isFile()) &&
+      (await lstat(join(path, "raw"))).isDirectory() &&
+      (await lstat(join(path, "wiki"))).isDirectory()
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function discoverWikiPath(start: string): Promise<string> {
+  const candidates = new Set<string>();
+  let directory = resolve(start);
+  while (true) {
+    for (const candidate of [directory, join(directory, "llm-wiki")]) {
+      if (await isWikiRepository(candidate)) {
+        candidates.add(await realpath(candidate));
+      }
+    }
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  if (candidates.size === 0) {
     throw new Error(
-      "LLM_WIKI_PATH is not set. Set it to the local wiki clone path. " +
-        "Set LLM_WIKI_REMOTE too when the extension must create the clone.",
+      "No llm-wiki Git repository with raw/ and wiki/ was found. " +
+        "Run Pi in or near the repository, or set LLM_WIKI_PATH.",
     );
   }
+  if (candidates.size > 1) {
+    throw new Error(
+      `Several llm-wiki repositories were found; set LLM_WIKI_PATH: ${[...candidates].join(", ")}`,
+    );
+  }
+  return [...candidates][0];
+}
+
+async function configFromEnvironment(): Promise<WikiConfig> {
+  const configuredPath = process.env.LLM_WIKI_PATH;
+  const path = configuredPath
+    ? resolve(configuredPath.replace(/^~(?=$|\/)/, homedir()))
+    : await discoverWikiPath(process.cwd());
+  if (basename(path) !== "llm-wiki") {
+    throw new Error(`Wiki repository must be named llm-wiki: ${path}`);
+  }
   return {
-    path: resolve(configuredPath.replace(/^~(?=$|\/)/, homedir())),
+    path,
     remote: process.env.LLM_WIKI_REMOTE,
     branch: process.env.LLM_WIKI_BRANCH || "main",
   };
@@ -156,11 +206,22 @@ export class GitWikiRepository {
         this.config.path,
         signal,
       );
+      const guidanceFiles: string[] = [];
+      for (const path of GUIDANCE_FILES) {
+        try {
+          if ((await lstat(join(this.config.path, path))).isFile()) {
+            guidanceFiles.push(path);
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+      }
       return {
         path: this.config.path,
         branch: this.config.branch,
         upstream,
         commit,
+        guidanceFiles,
       };
     });
   }
@@ -358,6 +419,31 @@ export class GitWikiRepository {
     const paths = changes.map((change) => validateRelativePath(change.path));
     if (new Set(paths).size !== paths.length)
       throw new Error("apply contains duplicate paths");
+    for (const [index, change] of changes.entries()) {
+      const path = paths[index];
+      if (change.role === "source" && !path.startsWith("raw/")) {
+        throw new Error(`A source role requires a raw/ path: ${path}`);
+      }
+      if (
+        ["concept", "index", "log"].includes(change.role) &&
+        !path.startsWith("wiki/")
+      ) {
+        throw new Error(`${change.role} role requires a wiki/ path: ${path}`);
+      }
+      if (
+        change.role === "schema" &&
+        !GUIDANCE_FILES.includes(path as (typeof GUIDANCE_FILES)[number])
+      ) {
+        throw new Error(
+          `A schema role requires a known root schema path: ${path}`,
+        );
+      }
+      if (
+        !["source", "concept", "index", "log", "schema"].includes(change.role)
+      ) {
+        throw new Error(`Unknown wiki file role: ${change.role}`);
+      }
+    }
     const bytes = changes.reduce(
       (sum, change) => sum + Buffer.byteLength(change.content),
       0,
@@ -463,6 +549,11 @@ export class GitWikiRepository {
   }
 
   private async ensureClone(signal?: AbortSignal): Promise<void> {
+    if (basename(this.config.path) !== "llm-wiki") {
+      throw new Error(
+        `Wiki repository must be named llm-wiki: ${this.config.path}`,
+      );
+    }
     try {
       await lstat(join(this.config.path, ".git"));
     } catch (error) {
@@ -486,6 +577,11 @@ export class GitWikiRepository {
         signal,
         60_000,
       );
+    }
+    for (const directory of ["raw", "wiki"]) {
+      if (!(await lstat(join(this.config.path, directory))).isDirectory()) {
+        throw new Error(`Wiki repository requires a ${directory}/ directory`);
+      }
     }
   }
 
@@ -649,8 +745,9 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
       "Use llm_wiki for wiki repository access instead of direct Git commands or direct file mutation.",
       "Follow the Karpathy LLM Wiki pattern: preserve source material, maintain derived knowledge separately, search before creating pages, integrate new evidence, and keep provenance.",
       "Write OKF v0.2 concept documents as Markdown with YAML frontmatter and a non-empty type; preserve unknown types and fields, and use index.md and log.md only as reserved documents.",
-      "Discover and preserve the connected repository layout; do not require raw/, wiki/, SPEC.md, AGENTS.md, or another repository-specific path.",
-      "For llm_wiki apply, label each file as source, concept, index, or log and submit every file for one complete semantic operation.",
+      "Start each semantic operation with llm_wiki status, then read every reported guidance file before other wiki content.",
+      "The repository is named llm-wiki; preserve immutable source material under raw/ and derived knowledge under wiki/.",
+      "For llm_wiki apply, label each file as source, concept, index, log, or schema and submit every file for one complete semantic operation.",
       "Preserve only non-sensitive personal facts stated by the user; never store secrets or inferred sensitive facts.",
     ],
     parameters: Type.Object({
@@ -675,7 +772,13 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
         Type.Array(
           Type.Object({
             path: Type.String(),
-            role: StringEnum(["source", "concept", "index", "log"] as const),
+            role: StringEnum([
+              "source",
+              "concept",
+              "index",
+              "log",
+              "schema",
+            ] as const),
             content: Type.String(),
             expected_sha256: Type.Optional(Type.String()),
           }),
@@ -684,7 +787,7 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
       ),
     }),
     async execute(_toolCallId, params, signal) {
-      const config = configFromEnvironment();
+      const config = await configFromEnvironment();
       const repository = new GitWikiRepository(config, (args, options) =>
         pi.exec("git", args, options),
       );
@@ -692,7 +795,7 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
       if (params.action === "status") {
         const status = await repository.status(signal);
         return textResult(
-          `Wiki synchronized at ${status.commit}\nPath: ${status.path}\nUpstream: ${status.upstream}`,
+          `Wiki synchronized at ${status.commit}\nPath: ${status.path}\nUpstream: ${status.upstream}\nGuidance: ${((status.guidanceFiles as string[]) ?? []).join(", ") || "none"}`,
           status,
         );
       }
@@ -757,25 +860,25 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
     "wiki-capture",
     "Capture and ingest a source into the Git-backed LLM wiki",
     (source) =>
-      `Capture and ingest this source into the LLM wiki: ${source}\nUse llm_wiki only for repository access. Discover and preserve the existing layout. Follow the built-in Karpathy and OKF workflow. Submit the complete operation with one apply action.`,
+      `Capture and ingest this source into the LLM wiki: ${source}\nUse llm_wiki only for repository access. Call status and read every reported guidance file first. Follow the built-in Karpathy and OKF workflow. Submit the complete operation with one apply action.`,
   );
   registerWorkflowCommand(
     "wiki-query",
     "Answer a question from the Git-backed LLM wiki",
     (question) =>
-      `Answer this question from the LLM wiki: ${question}\nUse llm_wiki to discover the layout, search, and read the supporting pages. Keep the query read-only unless I explicitly request a filed note.`,
+      `Answer this question from the LLM wiki: ${question}\nUse llm_wiki to call status and read every reported guidance file first. Then search and read the supporting pages. Keep the query read-only unless I explicitly request a filed note.`,
   );
   registerWorkflowCommand(
     "wiki-observe",
     "Preserve a durable personal fact in the Git-backed LLM wiki",
     (observation) =>
-      `Preserve this user-stated observation in the LLM wiki: ${observation}\nUse llm_wiki only for repository access. Discover and preserve the existing layout. Do not infer or store sensitive facts. Submit the complete operation with one observation apply action.`,
+      `Preserve this user-stated observation in the LLM wiki: ${observation}\nUse llm_wiki only for repository access. Call status and read every reported guidance file first. Do not infer or store sensitive facts. Submit the complete operation with one observation apply action.`,
   );
   registerWorkflowCommand(
     "wiki-lint",
     "Inspect the Git-backed LLM wiki without changing it",
     () =>
-      "Lint the LLM wiki. Use llm_wiki to discover the layout and inspect its OKF concepts, links, indexes, logs, and provenance. Report findings only. Do not apply fixes.",
+      "Lint the LLM wiki. Use llm_wiki to call status and read every reported guidance file first. Inspect its OKF concepts, links, indexes, logs, and provenance. Report findings only. Do not apply fixes.",
     false,
   );
   registerWorkflowCommand(

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -49,8 +49,11 @@ export interface WikiConfig {
   branch: string;
 }
 
+export type WikiFileRole = "source" | "concept" | "index" | "log";
+
 export interface WikiChange {
   path: string;
+  role: WikiFileRole;
   content: string;
   expected_sha256?: string;
 }
@@ -196,9 +199,7 @@ export class GitWikiRepository {
     return this.withLock(async () => {
       await this.ensureClone(signal);
       const commit = await this.synchronize(signal);
-      const pathspecs = (paths ?? ["wiki", "raw", "AGENTS.md"]).map(
-        validateRelativePath,
-      );
+      const pathspecs = paths?.map(validateRelativePath) ?? [];
       const result = await this.runGit(
         ["grep", "-Fni", "--", query, ...pathspecs],
         { cwd: this.config.path, signal, timeout: 15_000 },
@@ -252,7 +253,7 @@ export class GitWikiRepository {
           );
         }
 
-        await this.validateWorktree(worktree, actualPaths, signal);
+        await this.validateWorktree(worktree, changes, signal);
         await this.git(
           ["-c", "core.hooksPath=/dev/null", "commit", "-m", message],
           worktree,
@@ -357,13 +358,6 @@ export class GitWikiRepository {
     const paths = changes.map((change) => validateRelativePath(change.path));
     if (new Set(paths).size !== paths.length)
       throw new Error("apply contains duplicate paths");
-    if (
-      paths.some(
-        (path) => !path.startsWith("raw/") && !path.startsWith("wiki/"),
-      )
-    ) {
-      throw new Error("apply can change only raw/ and wiki/ paths");
-    }
     const bytes = changes.reduce(
       (sum, change) => sum + Buffer.byteLength(change.content),
       0,
@@ -392,8 +386,9 @@ export class GitWikiRepository {
         throw new Error(`Expected existing file is missing: ${path}`);
       }
     } else {
-      if (path.startsWith("raw/"))
-        throw new Error(`Raw source is immutable: ${path}`);
+      if (change.role === "source") {
+        throw new Error(`Source material is immutable: ${path}`);
+      }
       if (!change.expected_sha256) {
         throw new Error(`Existing file requires expected_sha256: ${path}`);
       }
@@ -428,21 +423,39 @@ export class GitWikiRepository {
 
   private async validateWorktree(
     worktree: string,
-    changedPaths: string[],
+    changes: WikiChange[],
     signal?: AbortSignal,
   ): Promise<void> {
-    await lstat(join(worktree, "AGENTS.md"));
-    for (const path of changedPaths) {
-      if (!path.startsWith("wiki/") || !path.endsWith(".md")) continue;
-      const name = basename(path).toLowerCase();
-      if (name === "index.md" || name === "log.md") continue;
+    for (const change of changes) {
+      const path = validateRelativePath(change.path);
+      if (change.role === "source") continue;
+      if (!path.endsWith(".md")) {
+        throw new Error(
+          `${change.role} files must use the .md suffix: ${path}`,
+        );
+      }
+      if (
+        change.role === "index" &&
+        basename(path).toLowerCase() !== "index.md"
+      ) {
+        throw new Error(
+          `An index role requires the reserved index.md name: ${path}`,
+        );
+      }
+      if (change.role === "log" && basename(path).toLowerCase() !== "log.md") {
+        throw new Error(
+          `A log role requires the reserved log.md name: ${path}`,
+        );
+      }
+      if (change.role !== "concept") continue;
+
       const content = await readFile(join(worktree, path), "utf8");
       const closing = content.indexOf("\n---\n", 4);
       const frontmatter = closing < 0 ? "" : content.slice(4, closing);
       const type = frontmatter.match(/^type:\s*(.+)$/m)?.[1]?.trim();
       if (!type || type.startsWith("#")) {
         throw new Error(
-          `Wiki page requires valid frontmatter with type: ${path}`,
+          `OKF concept requires valid frontmatter with type: ${path}`,
         );
       }
     }
@@ -474,7 +487,6 @@ export class GitWikiRepository {
         60_000,
       );
     }
-    await lstat(join(this.config.path, "AGENTS.md"));
   }
 
   private async synchronize(signal?: AbortSignal): Promise<string> {
@@ -635,8 +647,10 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
     promptGuidelines: [
       "Use llm_wiki when the user asks to capture, ingest, query, or lint wiki knowledge, or to preserve a durable personal fact.",
       "Use llm_wiki for wiki repository access instead of direct Git commands or direct file mutation.",
-      "Read the repository AGENTS.md with llm_wiki before an apply action and follow it as the semantic authority.",
-      "Submit every new or changed file for one complete semantic operation in one llm_wiki apply action.",
+      "Follow the Karpathy LLM Wiki pattern: preserve source material, maintain derived knowledge separately, search before creating pages, integrate new evidence, and keep provenance.",
+      "Write OKF v0.2 concept documents as Markdown with YAML frontmatter and a non-empty type; preserve unknown types and fields, and use index.md and log.md only as reserved documents.",
+      "Discover and preserve the connected repository layout; do not require raw/, wiki/, SPEC.md, AGENTS.md, or another repository-specific path.",
+      "For llm_wiki apply, label each file as source, concept, index, or log and submit every file for one complete semantic operation.",
       "Preserve only non-sensitive personal facts stated by the user; never store secrets or inferred sensitive facts.",
     ],
     parameters: Type.Object({
@@ -661,6 +675,7 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
         Type.Array(
           Type.Object({
             path: Type.String(),
+            role: StringEnum(["source", "concept", "index", "log"] as const),
             content: Type.String(),
             expected_sha256: Type.Optional(Type.String()),
           }),
@@ -742,25 +757,25 @@ export default function llmWikiExtension(pi: ExtensionAPI) {
     "wiki-capture",
     "Capture and ingest a source into the Git-backed LLM wiki",
     (source) =>
-      `Capture and ingest this source into the LLM wiki: ${source}\nUse llm_wiki only for repository access. Read AGENTS.md first. Submit the complete operation with one apply action.`,
+      `Capture and ingest this source into the LLM wiki: ${source}\nUse llm_wiki only for repository access. Discover and preserve the existing layout. Follow the built-in Karpathy and OKF workflow. Submit the complete operation with one apply action.`,
   );
   registerWorkflowCommand(
     "wiki-query",
     "Answer a question from the Git-backed LLM wiki",
     (question) =>
-      `Answer this question from the LLM wiki: ${question}\nUse llm_wiki to read AGENTS.md, search, and read the supporting pages. Keep the query read-only unless I explicitly request a filed note.`,
+      `Answer this question from the LLM wiki: ${question}\nUse llm_wiki to discover the layout, search, and read the supporting pages. Keep the query read-only unless I explicitly request a filed note.`,
   );
   registerWorkflowCommand(
     "wiki-observe",
     "Preserve a durable personal fact in the Git-backed LLM wiki",
     (observation) =>
-      `Preserve this user-stated observation in the LLM wiki: ${observation}\nUse llm_wiki only for repository access. Read AGENTS.md first. Do not infer or store sensitive facts. Submit the complete operation with one observation apply action.`,
+      `Preserve this user-stated observation in the LLM wiki: ${observation}\nUse llm_wiki only for repository access. Discover and preserve the existing layout. Do not infer or store sensitive facts. Submit the complete operation with one observation apply action.`,
   );
   registerWorkflowCommand(
     "wiki-lint",
     "Inspect the Git-backed LLM wiki without changing it",
     () =>
-      "Lint the LLM wiki. Use llm_wiki to read AGENTS.md and inspect the complete relevant indexes. Report findings only. Do not apply fixes.",
+      "Lint the LLM wiki. Use llm_wiki to discover the layout and inspect its OKF concepts, links, indexes, logs, and provenance. Report findings only. Do not apply fixes.",
     false,
   );
   registerWorkflowCommand(

--- a/extensions/llm-wiki/test/llm-wiki.test.ts
+++ b/extensions/llm-wiki/test/llm-wiki.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import llmWikiExtension, {
+  discoverWikiPath,
   GitWikiRepository,
   type GitRunner,
 } from "../index.ts";
@@ -48,14 +49,17 @@ async function git(args: string[], cwd: string): Promise<string> {
 async function fixture(root: string) {
   const remote = join(root, "remote.git");
   const seed = join(root, "seed");
-  const clone = join(root, "wiki");
+  const clone = join(root, "llm-wiki");
 
   await git(["init", "--bare", remote], root);
   await git(["clone", remote, seed], root);
   await git(["switch", "-c", "main"], seed);
+  await mkdir(join(seed, "raw"), { recursive: true });
   await mkdir(join(seed, "wiki"), { recursive: true });
+  await writeFile(join(seed, "raw", ".gitkeep"), "");
+  await writeFile(join(seed, "SPEC.md"), "# Wiki format\n");
   await writeFile(join(seed, "wiki", "index.md"), "# Wiki\n");
-  await git(["add", "wiki/index.md"], seed);
+  await git(["add", "raw/.gitkeep", "SPEC.md", "wiki/index.md"], seed);
   await git(["commit", "-m", "seed wiki"], seed);
   await git(["push", "-u", "origin", "main"], seed);
   await git(["symbolic-ref", "HEAD", "refs/heads/main"], remote);
@@ -104,6 +108,8 @@ export default async function (): Promise<void> {
 
     const status = await repository.status();
     assert.equal(status.branch, "main");
+    assert.deepEqual(status.guidanceFiles, ["SPEC.md"]);
+    assert.equal(await discoverWikiPath(root), clone);
 
     const initial = await repository.read(["wiki/index.md"]);
     assert.equal(initial.files[0].content, "# Wiki\n");
@@ -162,6 +168,17 @@ export default async function (): Promise<void> {
     await expectFailure(
       readFile(join(verify, "wiki", "hook.md"), "utf8"),
       "ENOENT",
+    );
+
+    await expectFailure(
+      repository.apply("ingest", "wiki: reject misplaced source", [
+        {
+          path: "wiki/misplaced-source.md",
+          role: "source",
+          content: "source\n",
+        },
+      ]),
+      "source role requires a raw/ path",
     );
 
     await expectFailure(

--- a/extensions/llm-wiki/test/llm-wiki.test.ts
+++ b/extensions/llm-wiki/test/llm-wiki.test.ts
@@ -54,9 +54,8 @@ async function fixture(root: string) {
   await git(["clone", remote, seed], root);
   await git(["switch", "-c", "main"], seed);
   await mkdir(join(seed, "wiki"), { recursive: true });
-  await writeFile(join(seed, "AGENTS.md"), "# wiki schema\n");
   await writeFile(join(seed, "wiki", "index.md"), "# Wiki\n");
-  await git(["add", "AGENTS.md", "wiki/index.md"], seed);
+  await git(["add", "wiki/index.md"], seed);
   await git(["commit", "-m", "seed wiki"], seed);
   await git(["push", "-u", "origin", "main"], seed);
   await git(["symbolic-ref", "HEAD", "refs/heads/main"], remote);
@@ -122,15 +121,18 @@ export default async function (): Promise<void> {
       [
         {
           path: "raw/sources/editor-preference.md",
+          role: "source",
           content: "I prefer modal editors.\n",
         },
         {
           path: "wiki/sources/editor-preference.md",
+          role: "concept",
           content:
             "---\ntype: Source\ntitle: Editor preference\n---\n\n# Editor preference\n\nThe user prefers modal editors.\n",
         },
         {
           path: "wiki/index.md",
+          role: "index",
           expected_sha256: initial.files[0].sha256,
           content:
             "# Wiki\n\n- [Editor preference](sources/editor-preference.md)\n",
@@ -166,6 +168,7 @@ export default async function (): Promise<void> {
       repository.apply("query-note", "wiki: reject malformed note", [
         {
           path: "wiki/notes/malformed.md",
+          role: "concept",
           content: "---\ntype: Note\n\nMissing closing delimiter.\n",
         },
       ]),
@@ -176,6 +179,7 @@ export default async function (): Promise<void> {
       repository.apply("query-note", "wiki: add stale note", [
         {
           path: "wiki/index.md",
+          role: "index",
           expected_sha256: "0".repeat(64),
           content: "# Changed\n",
         },
@@ -187,11 +191,12 @@ export default async function (): Promise<void> {
       repository.apply("ingest", "wiki: reject raw update", [
         {
           path: "raw/sources/editor-preference.md",
+          role: "source",
           expected_sha256: "0".repeat(64),
           content: "changed\n",
         },
       ]),
-      "Raw source is immutable",
+      "Source material is immutable",
     );
 
     const outside = join(root, "outside.md");
@@ -204,6 +209,7 @@ export default async function (): Promise<void> {
       repository.apply("query-note", "wiki: reject symbolic link", [
         {
           path: "wiki/link.md",
+          role: "concept",
           expected_sha256: "0".repeat(64),
           content: "changed\n",
         },

--- a/extensions/llm-wiki/test/llm-wiki.test.ts
+++ b/extensions/llm-wiki/test/llm-wiki.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import llmWikiExtension, {
+  GitWikiRepository,
+  type GitRunner,
+} from "../index.ts";
+import { createMockPi } from "../../../nix/test/helpers.ts";
+
+const runGit: GitRunner = async (args, options) => {
+  const child = Bun.spawn(["git", ...args], {
+    cwd: options.cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Pi Pack Test",
+      GIT_AUTHOR_EMAIL: "pi-pack@example.invalid",
+      GIT_COMMITTER_NAME: "Pi Pack Test",
+      GIT_COMMITTER_EMAIL: "pi-pack@example.invalid",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    signal: options.signal,
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { stdout, stderr, code };
+};
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const result = await runGit(args, { cwd });
+  if (result.code !== 0) throw new Error(result.stderr);
+  return result.stdout.trim();
+}
+
+async function fixture(root: string) {
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  const clone = join(root, "wiki");
+
+  await git(["init", "--bare", remote], root);
+  await git(["clone", remote, seed], root);
+  await git(["switch", "-c", "main"], seed);
+  await mkdir(join(seed, "wiki"), { recursive: true });
+  await writeFile(join(seed, "AGENTS.md"), "# wiki schema\n");
+  await writeFile(join(seed, "wiki", "index.md"), "# Wiki\n");
+  await git(["add", "AGENTS.md", "wiki/index.md"], seed);
+  await git(["commit", "-m", "seed wiki"], seed);
+  await git(["push", "-u", "origin", "main"], seed);
+  await git(["symbolic-ref", "HEAD", "refs/heads/main"], remote);
+
+  return {
+    remote,
+    clone,
+    repository: new GitWikiRepository(
+      { path: clone, remote, branch: "main" },
+      runGit,
+    ),
+  };
+}
+
+async function expectFailure(
+  work: Promise<unknown>,
+  message: string,
+): Promise<void> {
+  try {
+    await work;
+    assert.fail(`Expected failure containing: ${message}`);
+  } catch (error) {
+    assert.match(
+      error instanceof Error ? error.message : String(error),
+      new RegExp(message),
+    );
+  }
+}
+
+export default async function (): Promise<void> {
+  const mock = createMockPi();
+  llmWikiExtension(mock.pi as never);
+  assert.deepEqual([...mock.tools.keys()], ["llm_wiki"]);
+  assert.deepEqual(
+    [...mock.commands.keys()],
+    ["wiki-capture", "wiki-query", "wiki-observe", "wiki-lint", "wiki-status"],
+  );
+  await mock.commands.get("wiki-query")!.handler("stored knowledge", {
+    hasUI: false,
+  });
+  assert.match(String(mock.sentUserMessages[0]), /stored knowledge/);
+
+  const root = await mkdtemp(join(tmpdir(), "pi-pack-llm-wiki-test-"));
+  try {
+    const { remote, clone, repository } = await fixture(root);
+
+    const status = await repository.status();
+    assert.equal(status.branch, "main");
+
+    const initial = await repository.read(["wiki/index.md"]);
+    assert.equal(initial.files[0].content, "# Wiki\n");
+
+    const hook = join(clone, ".git", "hooks", "pre-commit");
+    await writeFile(
+      hook,
+      "#!/bin/sh\nprintf 'hook mutation\\n' > wiki/hook.md\ngit add wiki/hook.md\n",
+    );
+    await chmod(hook, 0o755);
+
+    const result = await repository.apply(
+      "observation",
+      "wiki: remember editor preference",
+      [
+        {
+          path: "raw/sources/editor-preference.md",
+          content: "I prefer modal editors.\n",
+        },
+        {
+          path: "wiki/sources/editor-preference.md",
+          content:
+            "---\ntype: Source\ntitle: Editor preference\n---\n\n# Editor preference\n\nThe user prefers modal editors.\n",
+        },
+        {
+          path: "wiki/index.md",
+          expected_sha256: initial.files[0].sha256,
+          content:
+            "# Wiki\n\n- [Editor preference](sources/editor-preference.md)\n",
+        },
+      ],
+    );
+
+    assert.deepEqual(result.changedPaths, [
+      "raw/sources/editor-preference.md",
+      "wiki/index.md",
+      "wiki/sources/editor-preference.md",
+    ]);
+    assert.match(
+      await readFile(join(clone, "wiki", "index.md"), "utf8"),
+      /Editor preference/,
+    );
+
+    const verify = join(root, "verify");
+    await git(["clone", remote, verify], root);
+    assert.match(
+      await readFile(
+        join(verify, "wiki", "sources", "editor-preference.md"),
+        "utf8",
+      ),
+      /modal editors/,
+    );
+    await expectFailure(
+      readFile(join(verify, "wiki", "hook.md"), "utf8"),
+      "ENOENT",
+    );
+
+    await expectFailure(
+      repository.apply("query-note", "wiki: reject malformed note", [
+        {
+          path: "wiki/notes/malformed.md",
+          content: "---\ntype: Note\n\nMissing closing delimiter.\n",
+        },
+      ]),
+      "requires valid frontmatter",
+    );
+
+    await expectFailure(
+      repository.apply("query-note", "wiki: add stale note", [
+        {
+          path: "wiki/index.md",
+          expected_sha256: "0".repeat(64),
+          content: "# Changed\n",
+        },
+      ]),
+      "File changed since it was read",
+    );
+
+    await expectFailure(
+      repository.apply("ingest", "wiki: reject raw update", [
+        {
+          path: "raw/sources/editor-preference.md",
+          expected_sha256: "0".repeat(64),
+          content: "changed\n",
+        },
+      ]),
+      "Raw source is immutable",
+    );
+
+    const outside = join(root, "outside.md");
+    await writeFile(outside, "outside\n");
+    await symlink(outside, join(clone, "wiki", "link.md"));
+    await git(["add", "wiki/link.md"], clone);
+    await git(["commit", "-m", "add test symbolic link"], clone);
+    await git(["push"], clone);
+    await expectFailure(
+      repository.apply("query-note", "wiki: reject symbolic link", [
+        {
+          path: "wiki/link.md",
+          expected_sha256: "0".repeat(64),
+          content: "changed\n",
+        },
+      ]),
+      "symbolic link",
+    );
+    await git(["rm", "wiki/link.md"], clone);
+    await git(["commit", "-m", "remove test symbolic link"], clone);
+    await git(["push"], clone);
+
+    const lockPath = `${clone}.llm-wiki-lock`;
+    await mkdir(lockPath);
+    await expectFailure(repository.status(), "holds the lock");
+    await rm(lockPath, { recursive: true });
+
+    await writeFile(join(clone, "untracked.md"), "dirty\n");
+    await expectFailure(repository.status(), "uncommitted changes");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,11 @@
                 assertions = [
                   {
                     assertion =
+                      builtins.elem "llm-wiki" selectedExtensions == builtins.elem pkgs.git config.home.packages;
+                    message = "Git installation must follow llm-wiki selection";
+                  }
+                  {
+                    assertion =
                       builtins.elem "sediment-memory" selectedExtensions
                       == builtins.elem self.packages.${pkgs.stdenv.hostPlatform.system}.sediment config.home.packages;
                     message = "Sediment installation must follow sediment-memory selection";
@@ -137,13 +142,23 @@
         home-manager-no-memory =
           (homeConfiguration pkgs (builtins.filter (name: name != "sediment-memory") extensions))
           .activationPackage;
-        extension-tests = pkgs.runCommand "pi-pack-extension-tests" { nativeBuildInputs = [ pkgs.bun ]; } ''
-          cp -r ${self} source
-          chmod -R u+w source
-          cd source
-          HOME=$TMPDIR bun --preload ./nix/test/preload.ts ./nix/test/run.ts
-          touch $out
-        '';
+        home-manager-no-wiki =
+          (homeConfiguration pkgs (builtins.filter (name: name != "llm-wiki") extensions)).activationPackage;
+        extension-tests =
+          pkgs.runCommand "pi-pack-extension-tests"
+            {
+              nativeBuildInputs = [
+                pkgs.bun
+                pkgs.git
+              ];
+            }
+            ''
+              cp -r ${self} source
+              chmod -R u+w source
+              cd source
+              HOME=$TMPDIR bun --preload ./nix/test/preload.ts ./nix/test/run.ts
+              touch $out
+            '';
         pi-compatibility =
           pkgs.runCommand "pi-pack-pi-compatibility"
             { nativeBuildInputs = [ llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.pi ]; }

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -24,6 +24,7 @@ let
     );
 
   resourcePackages = {
+    extensions.llm-wiki = [ pkgs.git ];
     extensions.sediment-memory = [ cfg.package.sediment ];
     skills = { };
   };

--- a/nix/test/preload.ts
+++ b/nix/test/preload.ts
@@ -14,6 +14,7 @@ class Component {
 mock.module("typebox", () => ({ Type: schema }));
 mock.module("@earendil-works/pi-ai", () => ({
   complete: async () => ({ content: [], stopReason: "stop" }),
+  StringEnum: () => ({}),
 }));
 mock.module("@earendil-works/pi-coding-agent", () => ({
   BorderedLoader: Component,

--- a/nix/test/run.ts
+++ b/nix/test/run.ts
@@ -1,5 +1,6 @@
 import btwTest from "../../extensions/btw/test/btw.test.ts";
 import clipboardTest from "../../extensions/clipboard/test/clipboard.test.ts";
+import llmWikiTest from "../../extensions/llm-wiki/test/llm-wiki.test.ts";
 import oracleTest from "../../extensions/oracle/test/oracle.test.ts";
 import piToPiTest from "../../extensions/pi-to-PI/test/pi-to-PI.test.ts";
 import sedimentMemoryTest from "../../extensions/sediment-memory/test/sediment-memory.test.ts";
@@ -8,6 +9,7 @@ import sketchTest from "../../extensions/sketch/test/sketch.test.ts";
 sedimentMemoryTest();
 await btwTest();
 await clipboardTest();
+await llmWikiTest();
 await oracleTest();
 await piToPiTest();
 await sketchTest();


### PR DESCRIPTION
## Summary

- add an `llm_wiki` tool for an existing Git-backed wiki
- discover a nearby repository named `llm-wiki` with `raw/` and `wiki/`
- synchronize the local clone before reads and mutations
- validate one complete change set, commit it, and push it without GitHub APIs
- embed the Karpathy LLM Wiki pattern and the OKF v0.2 document baseline
- report available repository guidance files before semantic work
- add `/wiki-capture`, `/wiki-query`, `/wiki-observe`, `/wiki-lint`, and `/wiki-status`
- install Git with the Home Manager extension selection

## Repository contract

The repository must be named `llm-wiki`. It must contain top-level `raw/` and `wiki/` directories. `LLM_WIKI_PATH` provides an optional override when automatic discovery is not sufficient.

The extension reports `AGENTS.md`, `CLAUDE.md`, `SPEC.md`, `WIKI_SCHEMA.md`, and `llm-wiki.md` when they exist. The agent reads the reported files before semantic work. The extension README documents discovery, roles, commands, and the Git transaction.

## Safety

The extension stops on dirty state, divergence, lock contention, stale file hashes, invalid paths, symbolic links, validation failures, and push rejection. It disables repository hooks for generated commits. It never force-pushes, stashes, rebases, or resolves conflicts.

## Verification

- `nix flake check -L`
