### PR TITLE
osm: add bounded OpenStreetMap CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 .pi/
+__pycache__/
+*.py[cod]
 *.log
+/result

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ pi-pack distributes Pi extensions, skills, prompt templates, and themes. Nix pac
 - `extensions/<name>/index.ts`: TypeScript extension entry points.
 - `extensions/<name>/README.md`: extension interface, configuration, lifecycle, and safety notes.
 - `extensions/<name>/test/<name>.test.ts`: colocated extension tests.
-- `skills/<name>/SKILL.md`: skill frontmatter and instructions. Keep referenced support files in the same skill directory.
+- `skills/<name>/SKILL.md`: skill frontmatter and instructions. Keep referenced support files and skill-owned CLIs in the same skill directory.
 - `prompts/*.md`: prompt templates. The filename becomes the slash command.
 - `themes/*.json`: complete Pi theme definitions.
 - `flake.nix`: resource discovery, package outputs, checks, and formatter configuration.
@@ -89,5 +89,7 @@ Run `nix fmt` after Nix, TypeScript, Markdown, or JSON changes. The formatter us
 Extensions run in the Pi process with user permissions. Skills can direct an agent to execute commands. Do not weaken the security notes in `README.md`.
 
 `sediment-memory` requires `sediment` in `PATH`. The Home Manager selection must install or remove both together.
+
+The `osm` skill requires `osm` in `PATH`. The Home Manager selection must install or remove `osm-cli` with the skill.
 
 The checks support `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Home Manager can deploy one skill for another agent:
 <summary><strong>osm</strong> - query OpenStreetMap</summary>
 
 - **Source:** [`skills/osm/`](skills/osm/)
-- **Use:** Find places, nearby points of interest, and public transport stops.
+- **CLI:** `osm`
+- **Requirement:** Configure `OSM_NOMINATIM_URL` for geocoding.
+- **Use:** Find places, nearby points of interest, and public transport stops with bounded normalized output.
 
 </details>
 
@@ -269,6 +271,7 @@ outputs:
 
 - `packages.<system>.default` — packaged pi assets under `share/pi-pack/`
 - `packages.<system>.sediment` — patched Sediment package for `sediment-memory`
+- `packages.<system>.osm-cli` — OpenStreetMap CLI for the `osm` skill
 - `checks.<system>.extension-tests` — mocked extension load and unit tests
 - `checks.<system>.pi-compatibility` — real extension load with Pi from `llm-agents.nix`
 - `homeModules.default` — Home Manager resource and Sediment deployment

--- a/flake.nix
+++ b/flake.nix
@@ -69,9 +69,10 @@
         };
 
       sedimentPackage = pkgs: pkgs.callPackage ./nix/packages/sediment/package.nix { };
+      osmCliPackage = pkgs: pkgs.callPackage ./skills/osm { };
 
       homeConfiguration =
-        pkgs: selectedExtensions:
+        pkgs: selectedExtensions: selectedSkills:
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           modules = [
@@ -87,6 +88,7 @@
                 programs.pi-pack = {
                   enable = true;
                   extensions = selectedExtensions;
+                  skills = selectedSkills;
                 };
                 assertions = [
                   {
@@ -99,6 +101,12 @@
                       builtins.elem "sediment-memory" selectedExtensions
                       == builtins.elem self.packages.${pkgs.stdenv.hostPlatform.system}.sediment config.home.packages;
                     message = "Sediment installation must follow sediment-memory selection";
+                  }
+                  {
+                    assertion =
+                      builtins.elem "osm" selectedSkills
+                      == builtins.elem self.packages.${pkgs.stdenv.hostPlatform.system}.osm-cli config.home.packages;
+                    message = "osm-cli installation must follow osm skill selection";
                   }
                 ];
               }
@@ -132,18 +140,24 @@
     {
       packages = eachSystem (pkgs: {
         default = package pkgs;
+        osm-cli = osmCliPackage pkgs;
         sediment = sedimentPackage pkgs;
       });
 
       checks = eachSystem (pkgs: {
         package = package pkgs;
+        osm-cli = osmCliPackage pkgs;
         sediment = sedimentPackage pkgs;
-        home-manager = (homeConfiguration pkgs extensions).activationPackage;
+        home-manager = (homeConfiguration pkgs extensions skills).activationPackage;
         home-manager-no-memory =
-          (homeConfiguration pkgs (builtins.filter (name: name != "sediment-memory") extensions))
+          (homeConfiguration pkgs (builtins.filter (name: name != "sediment-memory") extensions) skills)
           .activationPackage;
         home-manager-no-wiki =
-          (homeConfiguration pkgs (builtins.filter (name: name != "llm-wiki") extensions)).activationPackage;
+          (homeConfiguration pkgs (builtins.filter (name: name != "llm-wiki") extensions) skills)
+          .activationPackage;
+        home-manager-no-osm =
+          (homeConfiguration pkgs extensions (builtins.filter (name: name != "osm") skills))
+          .activationPackage;
         extension-tests =
           pkgs.runCommand "pi-pack-extension-tests"
             {

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -26,7 +26,7 @@ let
   resourcePackages = {
     extensions.llm-wiki = [ pkgs.git ];
     extensions.sediment-memory = [ cfg.package.sediment ];
-    skills = { };
+    skills.osm = [ cfg.package.osm-cli ];
   };
 in
 {

--- a/skills/osm/README.md
+++ b/skills/osm/README.md
@@ -1,0 +1,119 @@
+# osm
+
+A bounded OpenStreetMap CLI and Pi skill for geocoding, reverse geocoding, and nearby place search.
+
+The CLI replaces raw `curl` commands and Overpass QL in agent instructions. It normalizes service responses into stable JSON and enforces conservative query bounds.
+
+## Setup
+
+Nearby searches with explicit coordinates work without Nominatim:
+
+```bash
+osm nearby cafe --at 52.5251,13.3694
+```
+
+Geocoding, reverse geocoding, and `--near` require a configured Nominatim endpoint.
+
+Read the [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/) before selecting an endpoint. The public service permits only moderate, user-triggered use and prohibits autocomplete, systematic queries, and complete POI downloads.
+
+```bash
+export OSM_NOMINATIM_URL="https://nominatim.openstreetmap.org"
+export OSM_USER_AGENT="my-osm-client/1.0 (contact@example.com)"
+```
+
+The CLI does not default to the public Nominatim service. This makes endpoint selection deliberate and lets operators switch providers without a software update.
+
+Optional Overpass configuration:
+
+```bash
+export OSM_OVERPASS_URL="https://overpass-api.de/api/interpreter"
+```
+
+The public Overpass endpoint is the default.
+
+## Interface
+
+```text
+osm geocode QUERY [--limit N]
+osm reverse LATITUDE LONGITUDE
+osm nearby CATEGORY (--near PLACE | --at LATITUDE,LONGITUDE)
+                   [--name NAME] [--radius METERS] [--limit N]
+```
+
+`CATEGORY` can be a built-in alias or an exact OSM `key=value` tag.
+
+Examples:
+
+```bash
+osm geocode "Köln Hauptbahnhof" --limit 2
+osm reverse 50.9431 6.9588
+osm nearby restaurant --near "Köln Hauptbahnhof"
+osm nearby public_transport --at 50.9431,6.9588 --radius 1000
+osm nearby tourism=museum --near "Köln Dom"
+```
+
+## Output
+
+Commands write JSON to standard output. Errors write a JSON document to standard error and exit with status 2.
+
+Nearby output has this shape:
+
+```json
+{
+  "command": "nearby",
+  "category": "cafe",
+  "center": {
+    "lat": 52.5251,
+    "lon": 13.3694,
+    "name": "Berlin Hauptbahnhof"
+  },
+  "radius_m": 500,
+  "results": [
+    {
+      "name": "Example Cafe",
+      "category": "amenity=cafe",
+      "distance_m": 184,
+      "lat": 52.524,
+      "lon": 13.371,
+      "address": "Example Street 1, Berlin",
+      "osm_type": "node",
+      "osm_id": 123,
+      "osm_url": "https://www.openstreetmap.org/node/123"
+    }
+  ],
+  "attribution": "© OpenStreetMap contributors"
+}
+```
+
+## Limits and policy controls
+
+- Results are limited to 20. The default is 10.
+- Search radius is limited to 10 kilometers. The default is 500 meters.
+- Overpass receives generated bounded queries only. The CLI does not accept raw Overpass QL.
+- Nominatim responses are cached under `$XDG_CACHE_HOME/pi-pack-osm/nominatim`.
+- A cross-process lock serializes Nominatim requests and keeps them at least one second apart.
+- HTTP responses are limited to 2 MiB.
+- HTTP requests time out after 20 seconds.
+- Output always carries OpenStreetMap attribution.
+
+Nearby coordinate searches send the search center to the configured Overpass endpoint. Geocoding requests send the query to the configured Nominatim endpoint. Do not submit confidential data.
+
+## Implementation
+
+The Python package has no runtime dependencies outside the standard library.
+
+- `osm_cli/cli.py` contains the CLI, clients, normalization, cache, distance, and policy controls.
+- `tests/test_cli.py` verifies the interface with in-memory HTTP responses.
+- `default.nix` builds and tests the package beside the skill that owns it.
+
+Run tests through Nix:
+
+```bash
+nix build .#checks.x86_64-linux.osm-cli
+```
+
+Run them directly when Python and pytest are available:
+
+```bash
+python -m pytest skills/osm/tests
+```

--- a/skills/osm/SKILL.md
+++ b/skills/osm/SKILL.md
@@ -1,91 +1,80 @@
 ---
 name: osm
-description: search places, find nearby POIs, and locate public transport stops using OpenStreetMap. use when user asks about nearby restaurants, shops, pharmacies, transit stops, or any real-world location query.
+description: Search places, find nearby points of interest, and locate public transport stops with OpenStreetMap.
 ---
 
-# osm
+# OpenStreetMap
 
-query OpenStreetMap via nominatim (geocoding) + overpass API (spatial queries). no API key needed.
+Use the `osm` CLI. Do not construct Nominatim URLs or Overpass QL.
 
-## rules
+## Geocoding policy
 
-- **read-only.** never edit or upload anything to OSM.
+Before using Nominatim, read and follow its public service policy:
 
-## geocoding — resolve address/place to coordinates
+<https://operations.osmfoundation.org/policies/nominatim/>
 
-```
-curl -s -H "User-Agent: pi-pack/1.0" "https://nominatim.openstreetmap.org/search?q=<ADDRESS>&format=json&limit=3"
-```
+The user must deliberately configure `OSM_NOMINATIM_URL`. Never use Nominatim for autocomplete, bulk geocoding, systematic queries, or complete POI downloads. Do not submit personal or confidential data.
 
-returns `lat`, `lon`, `display_name`. use coordinates for overpass queries.
+## Commands
 
-## reverse geocoding — coordinates to address
+Resolve a place:
 
-```
-curl -s -H "User-Agent: pi-pack/1.0" "https://nominatim.openstreetmap.org/reverse?lat=<LAT>&lon=<LON>&format=json"
+```bash
+osm geocode "Berlin Hauptbahnhof"
 ```
 
-## overpass — spatial queries
+Resolve coordinates:
 
-endpoint: `https://overpass-api.de/api/interpreter`
-
-### find nearby POIs
-
-```
-[out:json];
-node["amenity"="<TYPE>"](around:<RADIUS>,<LAT>,<LON>);
-out body 10;
+```bash
+osm reverse 52.5251 13.3694
 ```
 
-common amenity values: `restaurant`, `cafe`, `pharmacy`, `hospital`, `atm`, `supermarket`, `parking`, `fuel`, `pub`, `bar`, `fast_food`, `dentist`, `doctors`
+Find nearby places from a named center:
 
-### find nearby shops
-
-```
-[out:json];
-node["shop"="<TYPE>"](around:<RADIUS>,<LAT>,<LON>);
-out body 10;
+```bash
+osm nearby restaurant --near "Berlin Hauptbahnhof"
+osm nearby public_transport --near "Hamburg Hbf" --radius 1000
 ```
 
-common shop values: `supermarket`, `bakery`, `butcher`, `convenience`, `clothes`, `hairdresser`, `hardware`, `electronics`
+Find nearby places from coordinates:
 
-### find nearby public transport stops
-
-```
-[out:json];
-node["public_transport"="stop_position"](around:<RADIUS>,<LAT>,<LON>);
-out body 10;
+```bash
+osm nearby pharmacy --at 52.5251,13.3694
 ```
 
-### find by name
+Use an OSM tag when no category alias exists:
 
-```
-[out:json];
-node["name"~"<PATTERN>",i](around:<RADIUS>,<LAT>,<LON>);
-out body 10;
+```bash
+osm nearby tourism=museum --near "München Marienplatz"
 ```
 
-### combine multiple types
+Filter by name:
 
-```
-[out:json];
-(
-  node["amenity"="restaurant"](around:500,<LAT>,<LON>);
-  node["amenity"="cafe"](around:500,<LAT>,<LON>);
-);
-out body 10;
+```bash
+osm nearby any --near "Leipzig" --name "Central"
 ```
 
-default radius: 500m. increase to 1000 if too few results.
+Defaults are a 500-meter radius and 10 results. The maximums are 10 kilometers and 20 results.
 
-## presenting results
+## Categories
 
-- sort by distance from query point
-- show: name, type, approximate distance, address (if in tags)
-- for transport stops: include transport type from tags
+Common aliases include:
 
-## notes
+- `restaurant`, `cafe`, `pharmacy`, and `hospital`
+- `supermarket` and `bakery`
+- `public_transport`
+- `any`
 
-- nominatim: max 1 req/s, User-Agent header required
-- overpass: free, no auth
-- works worldwide
+## Results
+
+The CLI returns bounded JSON. Nearby results are sorted by distance and include normalized names, categories, coordinates, addresses, and OSM links.
+
+When presenting results:
+
+- Include the approximate distance.
+- Include the address when available.
+- Include the OSM link.
+- State `© OpenStreetMap contributors`.
+- Say when OSM has no matching result. Do not claim that no real-world place exists.
+
+The skill is read-only. Never edit or upload OSM data.

--- a/skills/osm/default.nix
+++ b/skills/osm/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  python3,
+}:
+python3.pkgs.buildPythonApplication {
+  pname = "osm-cli";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  nativeCheckInputs = [ python3.pkgs.pytestCheckHook ];
+
+  pythonImportsCheck = [ "osm_cli" ];
+
+  meta = {
+    description = "Bounded OpenStreetMap place search for AI agents";
+    homepage = "https://github.com/fosskar/pi-pack";
+    license = lib.licenses.mit;
+    mainProgram = "osm";
+  };
+}

--- a/skills/osm/osm_cli/__init__.py
+++ b/skills/osm/osm_cli/__init__.py
@@ -1,0 +1,3 @@
+"""OpenStreetMap command-line client."""
+
+__version__ = "0.1.0"

--- a/skills/osm/osm_cli/__main__.py
+++ b/skills/osm/osm_cli/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/skills/osm/osm_cli/cli.py
+++ b/skills/osm/osm_cli/cli.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+ATTRIBUTION = "© OpenStreetMap contributors"
+NOMINATIM_POLICY = "https://operations.osmfoundation.org/policies/nominatim/"
+DEFAULT_OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+DEFAULT_USER_AGENT = "pi-pack-osm/0.1 (+https://github.com/fosskar/pi-pack)"
+MAX_LIMIT = 20
+MAX_RADIUS = 10_000
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+
+CATEGORIES: dict[str, list[tuple[str, str | None]]] = {
+    "any": [("name", None)],
+    "restaurant": [("amenity", "restaurant")],
+    "cafe": [("amenity", "cafe")],
+    "pharmacy": [("amenity", "pharmacy")],
+    "hospital": [("amenity", "hospital")],
+    "supermarket": [("shop", "supermarket")],
+    "bakery": [("shop", "bakery")],
+    "public_transport": [
+        ("public_transport", "platform"),
+        ("public_transport", "stop_position"),
+        ("highway", "bus_stop"),
+        ("railway", "station"),
+        ("railway", "halt"),
+        ("railway", "tram_stop"),
+    ],
+}
+TAG_PATTERN = re.compile(r"^[A-Za-z0-9_:.-]+$")
+
+
+class CliError(Exception):
+    def __init__(self, code: str, message: str, **details: Any) -> None:
+        super().__init__(message)
+        self.document = {"error": code, "message": message, **details}
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise CliError("invalid_arguments", message)
+
+
+class HttpClient:
+    def __init__(self, user_agent: str, timeout: float = 20) -> None:
+        self.headers = {"Accept": "application/json", "User-Agent": user_agent}
+        self.timeout = timeout
+
+    def get(self, url: str, parameters: Mapping[str, str]) -> Any:
+        url = f"{url}?{urllib.parse.urlencode(parameters)}"
+        return self._open(urllib.request.Request(url, headers=self.headers))
+
+    def post(self, url: str, parameters: Mapping[str, str]) -> Any:
+        request = urllib.request.Request(
+            url,
+            data=urllib.parse.urlencode(parameters).encode(),
+            headers={
+                **self.headers,
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            method="POST",
+        )
+        return self._open(request)
+
+    def _open(self, request: urllib.request.Request) -> Any:
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                payload = response.read(MAX_RESPONSE_BYTES + 1)
+        except urllib.error.HTTPError as error:
+            raise CliError(
+                "http_error", f"HTTP {error.code} from the map service"
+            ) from error
+        except urllib.error.URLError as error:
+            raise CliError("network_error", str(error.reason)) from error
+        if len(payload) > MAX_RESPONSE_BYTES:
+            raise CliError("response_too_large", "Map service response exceeded 2 MiB")
+        try:
+            return json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise CliError(
+                "invalid_response", "Map service returned invalid JSON"
+            ) from error
+
+
+def cache_directory(environment: Mapping[str, str]) -> Path:
+    root = Path(environment.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    directory = root / "pi-pack-osm" / "nominatim"
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    directory.chmod(0o700)
+    return directory
+
+
+def nominatim_request(
+    action: str,
+    parameters: Mapping[str, str],
+    environment: Mapping[str, str],
+    http: HttpClient,
+) -> Any:
+    endpoint = environment.get("OSM_NOMINATIM_URL")
+    if not endpoint:
+        raise CliError(
+            "nominatim_not_configured",
+            "Set OSM_NOMINATIM_URL after reviewing the Nominatim usage policy",
+            policy=NOMINATIM_POLICY,
+        )
+
+    directory = cache_directory(environment)
+    encoded = json.dumps(
+        {"endpoint": endpoint, "action": action, "parameters": parameters},
+        sort_keys=True,
+    ).encode()
+    cache = directory / f"{hashlib.sha256(encoded).hexdigest()}.json"
+    if cache.exists():
+        return json.loads(cache.read_text())
+
+    lock_path = directory / "request.lock"
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        lock_path.chmod(0o600)
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        if cache.exists():
+            return json.loads(cache.read_text())
+        lock.seek(0)
+        previous = lock.read().strip()
+        if previous:
+            time.sleep(max(0, 1 - (time.time() - float(previous))))
+        try:
+            result = http.get(f"{endpoint.rstrip('/')}/{action}", parameters)
+        finally:
+            lock.seek(0)
+            lock.truncate()
+            lock.write(str(time.time()))
+            lock.flush()
+
+        temporary = directory / f".{cache.name}.{os.getpid()}.tmp"
+        temporary.write_text(json.dumps(result, ensure_ascii=False, allow_nan=False))
+        temporary.chmod(0o600)
+        temporary.replace(cache)
+        return result
+
+
+def geocode(
+    query: str,
+    limit: int,
+    environment: Mapping[str, str],
+    http: HttpClient,
+) -> list[dict[str, Any]]:
+    payload = nominatim_request(
+        "search",
+        {"q": query, "format": "jsonv2", "addressdetails": "1", "limit": str(limit)},
+        environment,
+        http,
+    )
+    if not isinstance(payload, list):
+        raise CliError("invalid_response", "Nominatim search did not return a list")
+    results: list[dict[str, Any]] = []
+    for item in payload:
+        if isinstance(item, dict):
+            results.append(normalize_geocode(item))
+        if len(results) == limit:
+            break
+    return results
+
+
+def reverse(
+    latitude: float,
+    longitude: float,
+    environment: Mapping[str, str],
+    http: HttpClient,
+) -> dict[str, Any]:
+    payload = nominatim_request(
+        "reverse",
+        {
+            "lat": coordinate(latitude),
+            "lon": coordinate(longitude),
+            "format": "jsonv2",
+            "addressdetails": "1",
+        },
+        environment,
+        http,
+    )
+    if not isinstance(payload, dict) or "error" in payload:
+        raise CliError("not_found", "Nominatim did not find this coordinate")
+    return normalize_geocode(payload)
+
+
+def normalize_geocode(item: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        latitude, longitude = float(item["lat"]), float(item["lon"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise CliError(
+            "invalid_response", "Nominatim returned invalid coordinates"
+        ) from error
+    if not valid_coordinates(latitude, longitude):
+        raise CliError("invalid_response", "Nominatim returned invalid coordinates")
+
+    osm_type = str(item.get("osm_type", ""))
+    osm_id = item.get("osm_id")
+    result = {
+        "name": str(item.get("display_name") or item.get("name") or "Unnamed place"),
+        "lat": latitude,
+        "lon": longitude,
+        "category": item.get("category") or item.get("class"),
+        "type": item.get("type"),
+    }
+    if osm_type in {"node", "way", "relation"} and str(osm_id).isdigit():
+        result["osm_url"] = f"https://www.openstreetmap.org/{osm_type}/{osm_id}"
+    return result
+
+
+def nearby(
+    latitude: float,
+    longitude: float,
+    category: str,
+    name: str | None,
+    radius: int,
+    limit: int,
+    endpoint: str,
+    http: HttpClient,
+) -> list[dict[str, Any]]:
+    query = overpass_query(category_tags(category), name, radius, latitude, longitude)
+    payload = http.post(endpoint, {"data": query})
+    if not isinstance(payload, dict) or not isinstance(payload.get("elements"), list):
+        raise CliError("invalid_response", "Overpass did not return an elements list")
+
+    results: list[dict[str, Any]] = []
+    for element in payload["elements"]:
+        place = normalize_element(element, latitude, longitude)
+        if place:
+            results.append(place)
+    results.sort(key=lambda place: (place["distance_m"], place["name"].casefold()))
+    return results[:limit]
+
+
+def category_tags(category: str) -> list[tuple[str, str | None]]:
+    if category in CATEGORIES:
+        return CATEGORIES[category]
+    if "=" not in category:
+        raise CliError(
+            "unknown_category",
+            f"Unknown category: {category}",
+            aliases=sorted(CATEGORIES),
+        )
+    key, value = category.split("=", 1)
+    if not TAG_PATTERN.fullmatch(key) or not TAG_PATTERN.fullmatch(value):
+        raise CliError("invalid_category", "Invalid OSM key=value category")
+    return [(key, value)]
+
+
+def overpass_query(
+    tags: Sequence[tuple[str, str | None]],
+    name: str | None,
+    radius: int,
+    latitude: float,
+    longitude: float,
+) -> str:
+    escaped_name = ql(re.escape(name)) if name else None
+    name_filter = f'["name"~"{escaped_name}",i]' if escaped_name else ""
+    around = f"(around:{radius},{coordinate(latitude)},{coordinate(longitude)})"
+    selectors = []
+    for key, value in tags:
+        tag_filter = f'["{key}"]' if value is None else f'["{key}"="{value}"]'
+        selectors.append(f"nwr{tag_filter}{name_filter}{around};")
+    return "[out:json][timeout:20];(" + "".join(selectors) + ");out center 100;"
+
+
+def normalize_element(
+    element: Any, origin_latitude: float, origin_longitude: float
+) -> dict[str, Any] | None:
+    if not isinstance(element, dict) or not isinstance(element.get("tags"), dict):
+        return None
+    osm_type = element.get("type")
+    center = element if osm_type == "node" else element.get("center")
+    if osm_type not in {"node", "way", "relation"} or not isinstance(center, dict):
+        return None
+    try:
+        latitude, longitude = float(center["lat"]), float(center["lon"])
+        osm_id = int(element["id"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not valid_coordinates(latitude, longitude):
+        return None
+
+    tags = element["tags"]
+    category = next(
+        (
+            f"{key}={tags[key]}"
+            for key in ("amenity", "shop", "public_transport", "railway", "highway")
+            if key in tags
+        ),
+        "place",
+    )
+    address = tags.get("addr:full")
+    if not address:
+        street = " ".join(
+            str(value)
+            for value in (tags.get("addr:street"), tags.get("addr:housenumber"))
+            if value
+        )
+        address = (
+            ", ".join(
+                str(value)
+                for value in (street, tags.get("addr:postcode"), tags.get("addr:city"))
+                if value
+            )
+            or None
+        )
+    return {
+        "name": str(tags.get("name") or tags.get("ref") or "Unnamed place"),
+        "category": category,
+        "distance_m": round(
+            haversine(origin_latitude, origin_longitude, latitude, longitude)
+        ),
+        "lat": latitude,
+        "lon": longitude,
+        "address": address,
+        "osm_url": f"https://www.openstreetmap.org/{osm_type}/{osm_id}",
+    }
+
+
+def build_parser() -> Parser:
+    parser = Parser(prog="osm")
+    commands = parser.add_subparsers(dest="command", required=True)
+    geocode_parser = commands.add_parser("geocode")
+    geocode_parser.add_argument("query")
+    geocode_parser.add_argument("--limit", type=int, default=3)
+    reverse_parser = commands.add_parser("reverse")
+    reverse_parser.add_argument("latitude", type=float)
+    reverse_parser.add_argument("longitude", type=float)
+    nearby_parser = commands.add_parser("nearby")
+    nearby_parser.add_argument("category")
+    origin = nearby_parser.add_mutually_exclusive_group(required=True)
+    origin.add_argument("--near")
+    origin.add_argument("--at")
+    nearby_parser.add_argument("--name")
+    nearby_parser.add_argument("--radius", type=int, default=500)
+    nearby_parser.add_argument("--limit", type=int, default=10)
+    return parser
+
+
+def run(
+    arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str] | None = None,
+    http: HttpClient | None = None,
+) -> dict[str, Any]:
+    env = os.environ if environment is None else environment
+    args = build_parser().parse_args(arguments)
+    validate_limit(getattr(args, "limit", 1))
+    network = http or HttpClient(env.get("OSM_USER_AGENT", DEFAULT_USER_AGENT))
+
+    if args.command == "geocode":
+        return output("geocode", geocode(args.query, args.limit, env, network))
+    if args.command == "reverse":
+        validate_coordinates(args.latitude, args.longitude)
+        return output("reverse", reverse(args.latitude, args.longitude, env, network))
+
+    if not 1 <= args.radius <= MAX_RADIUS:
+        raise CliError(
+            "invalid_radius", f"radius must be between 1 and {MAX_RADIUS} meters"
+        )
+    if args.near:
+        matches = geocode(args.near, 1, env, network)
+        if not matches:
+            raise CliError("not_found", f"No location matched: {args.near}")
+        center = {
+            "lat": matches[0]["lat"],
+            "lon": matches[0]["lon"],
+            "name": matches[0]["name"],
+        }
+    else:
+        latitude, longitude = parse_at(args.at)
+        center = {"lat": latitude, "lon": longitude}
+
+    results = nearby(
+        center["lat"],
+        center["lon"],
+        args.category,
+        args.name,
+        args.radius,
+        args.limit,
+        env.get("OSM_OVERPASS_URL", DEFAULT_OVERPASS_URL),
+        network,
+    )
+    return {
+        "command": "nearby",
+        "category": args.category,
+        "center": center,
+        "radius_m": args.radius,
+        "results": results,
+        "attribution": ATTRIBUTION,
+    }
+
+
+def parse_at(value: str) -> tuple[float, float]:
+    try:
+        latitude, longitude = (float(part) for part in value.split(",", 1))
+    except (AttributeError, ValueError) as error:
+        raise CliError(
+            "invalid_coordinates", "--at requires LATITUDE,LONGITUDE"
+        ) from error
+    validate_coordinates(latitude, longitude)
+    return latitude, longitude
+
+
+def valid_coordinates(latitude: float, longitude: float) -> bool:
+    return (
+        math.isfinite(latitude)
+        and math.isfinite(longitude)
+        and -90 <= latitude <= 90
+        and -180 <= longitude <= 180
+    )
+
+
+def validate_coordinates(latitude: float, longitude: float) -> None:
+    if not valid_coordinates(latitude, longitude):
+        raise CliError(
+            "invalid_coordinates", "latitude or longitude is outside its valid range"
+        )
+
+
+def validate_limit(limit: int) -> None:
+    if not 1 <= limit <= MAX_LIMIT:
+        raise CliError("invalid_limit", f"limit must be between 1 and {MAX_LIMIT}")
+
+
+def ql(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def coordinate(value: float) -> str:
+    return f"{value:.7f}".rstrip("0").rstrip(".")
+
+
+def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    delta_phi, delta_lon = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
+    value = (
+        math.sin(delta_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(delta_lon / 2) ** 2
+    )
+    return 6_371_000 * 2 * math.atan2(math.sqrt(value), math.sqrt(1 - value))
+
+
+def output(command: str, results: Any) -> dict[str, Any]:
+    return {"command": command, "results": results, "attribution": ATTRIBUTION}
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    try:
+        result = run(sys.argv[1:] if arguments is None else arguments)
+    except CliError as error:
+        print(json.dumps(error.document, ensure_ascii=False), file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        return 130
+    print(json.dumps(result, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0

--- a/skills/osm/pyproject.toml
+++ b/skills/osm/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pi-pack-osm-cli"
+version = "0.1.0"
+description = "Bounded OpenStreetMap place search for AI agents"
+requires-python = ">=3.11"
+
+[project.scripts]
+osm = "osm_cli.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["osm_cli*"]

--- a/skills/osm/tests/test_cli.py
+++ b/skills/osm/tests/test_cli.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from osm_cli.cli import CliError, category_tags, haversine, overpass_query, run
+
+
+class FakeHttp:
+    def __init__(
+        self, *, get: list[Any] | None = None, post: list[Any] | None = None
+    ) -> None:
+        self.get_responses = get or []
+        self.post_responses = post or []
+        self.get_calls: list[tuple[str, dict[str, str]]] = []
+        self.post_calls: list[tuple[str, dict[str, str]]] = []
+
+    def get(self, url: str, parameters: dict[str, str]) -> Any:
+        self.get_calls.append((url, parameters))
+        return self.get_responses.pop(0)
+
+    def post(self, url: str, parameters: dict[str, str]) -> Any:
+        self.post_calls.append((url, parameters))
+        return self.post_responses.pop(0)
+
+
+class OsmCliTest(unittest.TestCase):
+    def environment(self, cache: str) -> dict[str, str]:
+        return {
+            "OSM_NOMINATIM_URL": "https://nominatim.example.test",
+            "OSM_OVERPASS_URL": "https://overpass.example.test/api",
+            "XDG_CACHE_HOME": cache,
+        }
+
+    def test_geocode_is_bounded_normalized_and_cached(self) -> None:
+        with tempfile.TemporaryDirectory() as cache:
+            place = {
+                "lat": "52.5251",
+                "lon": "13.3694",
+                "display_name": "Berlin Hauptbahnhof",
+                "category": "railway",
+                "type": "station",
+                "osm_type": "node",
+                "osm_id": 123,
+            }
+            http = FakeHttp(get=[[place, *[place] * 24]])
+            arguments = ["geocode", "Berlin Hauptbahnhof", "--limit", "1"]
+
+            first = run(arguments, environment=self.environment(cache), http=http)
+            second = run(arguments, environment=self.environment(cache), http=http)
+
+            self.assertEqual(first, second)
+            self.assertEqual(len(first["results"]), 1)
+            self.assertEqual(len(http.get_calls), 1)
+            self.assertEqual(first["results"][0]["lat"], 52.5251)
+            self.assertEqual(
+                first["results"][0]["osm_url"],
+                "https://www.openstreetmap.org/node/123",
+            )
+            directory = Path(cache) / "pi-pack-osm" / "nominatim"
+            self.assertEqual(stat.S_IMODE(directory.stat().st_mode), 0o700)
+            for path in directory.iterdir():
+                self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_geocode_requires_configuration(self) -> None:
+        with self.assertRaises(CliError) as raised:
+            run(["geocode", "Berlin"], environment={}, http=FakeHttp())
+        self.assertEqual(raised.exception.document["error"], "nominatim_not_configured")
+        self.assertIn("policy", raised.exception.document)
+
+    def test_geocode_rejects_invalid_coordinates(self) -> None:
+        with tempfile.TemporaryDirectory() as cache:
+            http = FakeHttp(get=[[{"lat": "nan", "lon": "13", "display_name": "bad"}]])
+            with self.assertRaises(CliError) as raised:
+                run(
+                    ["geocode", "bad"],
+                    environment=self.environment(cache),
+                    http=http,
+                )
+            self.assertEqual(raised.exception.document["error"], "invalid_response")
+
+    def test_nearby_normalizes_ways_and_sorts_results(self) -> None:
+        http = FakeHttp(
+            post=[
+                {
+                    "elements": [
+                        {
+                            "type": "way",
+                            "id": 20,
+                            "center": {"lat": 52.002, "lon": 13},
+                            "tags": {
+                                "name": "Far Cafe",
+                                "amenity": "cafe",
+                                "addr:street": "Far Street",
+                                "addr:housenumber": "2",
+                            },
+                        },
+                        {
+                            "type": "node",
+                            "id": 10,
+                            "lat": 52.0001,
+                            "lon": 13,
+                            "tags": {"name": "Near Cafe", "amenity": "cafe"},
+                        },
+                    ]
+                }
+            ]
+        )
+        result = run(
+            ["nearby", "cafe", "--at", "52,13", "--radius", "750"],
+            environment={"OSM_OVERPASS_URL": "https://overpass.example.test/api"},
+            http=http,
+        )
+
+        self.assertEqual(
+            [place["name"] for place in result["results"]],
+            ["Near Cafe", "Far Cafe"],
+        )
+        self.assertEqual(result["results"][1]["address"], "Far Street 2")
+        self.assertIn('["amenity"="cafe"]', http.post_calls[0][1]["data"])
+
+    def test_nearby_can_geocode_the_center(self) -> None:
+        with tempfile.TemporaryDirectory() as cache:
+            http = FakeHttp(
+                get=[[{"lat": "48.14", "lon": "11.56", "display_name": "München"}]],
+                post=[{"elements": []}],
+            )
+            result = run(
+                ["nearby", "pharmacy", "--near", "München"],
+                environment=self.environment(cache),
+                http=http,
+            )
+            self.assertEqual(result["center"]["name"], "München")
+            self.assertEqual(result["results"], [])
+
+    def test_public_transport_query_and_distance(self) -> None:
+        query = overpass_query(category_tags("public_transport"), None, 500, 52, 13)
+        self.assertIn('["public_transport"="platform"]', query)
+        self.assertIn('["highway"="bus_stop"]', query)
+        self.assertIn('["railway"="station"]', query)
+        self.assertAlmostEqual(haversine(0, 0, 0, 1), 111_195, delta=100)
+
+    def test_validates_bounds_and_categories(self) -> None:
+        cases = [
+            (["nearby", "cafe", "--at", "nan,0"], "invalid_coordinates"),
+            (["nearby", "cafe", "--at", "1,2", "--radius", "0"], "invalid_radius"),
+            (["nearby", "cafe", "--at", "1,2", "--limit", "21"], "invalid_limit"),
+            (["nearby", "unknown", "--at", "1,2"], "unknown_category"),
+        ]
+        for arguments, code in cases:
+            with self.subTest(arguments=arguments):
+                with self.assertRaises(CliError) as raised:
+                    run(
+                        arguments,
+                        environment={},
+                        http=FakeHttp(post=[{"elements": []}]),
+                    )
+                self.assertEqual(raised.exception.document["error"], code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace raw `curl` and Overpass QL instructions with a skill-owned `osm` CLI
- support geocoding, reverse geocoding, and bounded nearby place search
- normalize nodes, ways, and relations into stable distance-sorted JSON
- require deliberate Nominatim endpoint configuration and link its usage policy
- cache and rate-limit Nominatim requests across CLI processes
- install `osm-cli` with the selected Home Manager skill

## Repository layout

The CLI, tests, package definition, README, and `SKILL.md` remain together under `skills/osm/`.

## Safety

The CLI is read-only for OpenStreetMap. It limits results to 20, limits radius to 10 kilometers, limits HTTP responses to 2 MiB, and does not accept raw Overpass QL. It has no OSM editing or upload interface.

## Verification

- `nix flake check -L`
- Ruff check and format
- 7 Python tests
- live bounded Overpass query
