### PR TITLE
paperless: add read-only document CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,4 +92,6 @@ Extensions run in the Pi process with user permissions. Skills can direct an age
 
 The `osm` skill requires `osm` in `PATH`. The Home Manager selection must install or remove `osm-cli` with the skill.
 
+The `paperless` skill requires `paperless` in `PATH`. The Home Manager selection must install or remove `paperless-cli` with the skill.
+
 The checks support `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ Home Manager can deploy one skill for another agent:
 <summary><strong>paperless</strong> - search and browse paperless-ngx</summary>
 
 - **Source:** [`skills/paperless/`](skills/paperless/)
-- **Use:** Find documents, receipts, invoices, and scans.
+- **CLI:** `paperless`
+- **Requirement:** `PAPERLESS_URL` and `PAPERLESS_API_TOKEN`
+- **Use:** Search and read documents, receipts, invoices, and scans through a bounded read-only interface.
 
 </details>
 
@@ -272,6 +274,7 @@ outputs:
 - `packages.<system>.default` — packaged pi assets under `share/pi-pack/`
 - `packages.<system>.sediment` — patched Sediment package for `sediment-memory`
 - `packages.<system>.osm-cli` — OpenStreetMap CLI for the `osm` skill
+- `packages.<system>.paperless-cli` — read-only Paperless-ngx CLI for the `paperless` skill
 - `checks.<system>.extension-tests` — mocked extension load and unit tests
 - `checks.<system>.pi-compatibility` — real extension load with Pi from `llm-agents.nix`
 - `homeModules.default` — Home Manager resource and Sediment deployment

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
 
       sedimentPackage = pkgs: pkgs.callPackage ./nix/packages/sediment/package.nix { };
       osmCliPackage = pkgs: pkgs.callPackage ./skills/osm { };
+      paperlessCliPackage = pkgs: pkgs.callPackage ./skills/paperless { };
 
       homeConfiguration =
         pkgs: selectedExtensions: selectedSkills:
@@ -108,6 +109,13 @@
                       == builtins.elem self.packages.${pkgs.stdenv.hostPlatform.system}.osm-cli config.home.packages;
                     message = "osm-cli installation must follow osm skill selection";
                   }
+                  {
+                    assertion =
+                      builtins.elem "paperless" selectedSkills
+                      == builtins.elem self.packages.${pkgs.stdenv.hostPlatform.system}.paperless-cli
+                        config.home.packages;
+                    message = "paperless-cli installation must follow paperless skill selection";
+                  }
                 ];
               }
             )
@@ -141,12 +149,14 @@
       packages = eachSystem (pkgs: {
         default = package pkgs;
         osm-cli = osmCliPackage pkgs;
+        paperless-cli = paperlessCliPackage pkgs;
         sediment = sedimentPackage pkgs;
       });
 
       checks = eachSystem (pkgs: {
         package = package pkgs;
         osm-cli = osmCliPackage pkgs;
+        paperless-cli = paperlessCliPackage pkgs;
         sediment = sedimentPackage pkgs;
         home-manager = (homeConfiguration pkgs extensions skills).activationPackage;
         home-manager-no-memory =
@@ -157,6 +167,9 @@
           .activationPackage;
         home-manager-no-osm =
           (homeConfiguration pkgs extensions (builtins.filter (name: name != "osm") skills))
+          .activationPackage;
+        home-manager-no-paperless =
+          (homeConfiguration pkgs extensions (builtins.filter (name: name != "paperless") skills))
           .activationPackage;
         extension-tests =
           pkgs.runCommand "pi-pack-extension-tests"

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -27,6 +27,7 @@ let
     extensions.llm-wiki = [ pkgs.git ];
     extensions.sediment-memory = [ cfg.package.sediment ];
     skills.osm = [ cfg.package.osm-cli ];
+    skills.paperless = [ cfg.package.paperless-cli ];
   };
 in
 {

--- a/skills/paperless/README.md
+++ b/skills/paperless/README.md
@@ -1,0 +1,58 @@
+# paperless
+
+A strictly read-only Paperless-ngx CLI and Pi skill.
+
+The CLI replaces raw REST endpoint instructions with a small bounded interface. It exposes no raw request, upload, update, download, or delete command.
+
+## Configuration
+
+```bash
+export PAPERLESS_URL="https://paperless.example.com"
+export PAPERLESS_API_TOKEN="..."
+```
+
+Create the token in Paperless-ngx. The CLI sends it only through this header:
+
+```text
+Authorization: Token <token>
+```
+
+It also requests Paperless API version 10.
+
+## Interface
+
+```text
+paperless search QUERY [--limit N]
+paperless recent [--limit N]
+paperless document ID [--content-chars N]
+paperless metadata ID
+paperless tags [--limit N]
+paperless correspondents [--limit N]
+paperless document-types [--limit N]
+paperless custom-fields [--limit N]
+```
+
+Commands return JSON. Errors return JSON on standard error and exit with status 2.
+
+Search results contain selected document fields and a Paperless details URL. They omit OCR content. `document` returns bounded OCR content and reports truncation.
+
+## Limits and privacy
+
+- List commands return at most 50 results.
+- Document OCR output is limited to 50,000 characters.
+- HTTP responses are limited to 2 MiB.
+- HTTP requests time out after 20 seconds.
+- Every network request uses HTTP `GET`.
+- Redirects are rejected so the token stays on the configured origin.
+- The CLI has no arbitrary endpoint or method option.
+
+Document content can contain sensitive personal data. Protect `PAPERLESS_API_TOKEN` and command output. Use a Paperless token with read-only permissions when the server supports one.
+
+## Development
+
+The Python package has no runtime dependencies outside the standard library. The package definition stays beside the skill in `skills/paperless/default.nix`.
+
+```bash
+nix build .#checks.x86_64-linux.paperless-cli
+python -m pytest skills/paperless/tests
+```

--- a/skills/paperless/SKILL.md
+++ b/skills/paperless/SKILL.md
@@ -1,44 +1,57 @@
 ---
 name: paperless
-description: search and browse documents in paperless-ngx. use when the user asks about documents, receipts, invoices, scans, or anything related to their document archive.
+description: Search and read documents, receipts, invoices, and scans in Paperless-ngx.
 ---
 
-# paperless-ngx skill
+# Paperless-ngx
 
-## connection
+Use the read-only `paperless` CLI. Do not construct API requests with `curl`.
 
-- **base url:** `$PAPERLESS_URL`
-- **auth header:** `Authorization: Token $PAPERLESS_API_TOKEN`
-- require `PAPERLESS_URL` and `PAPERLESS_API_TOKEN` in environment
-- add `-H "Accept: application/json; version=10"` to all requests
+## Commands
 
-## rules
+Search OCR content and document metadata:
 
-- **read-only.** never delete, remove, upload, or create anything. no writes of any kind. if the user asks, refuse.
-- always show document IDs in results so the user can reference them
-- link to documents: `$PAPERLESS_URL/documents/{id}/details`
+```bash
+paperless search "health insurance"
+```
 
-## endpoints
+List recent documents:
 
-- `GET /api/documents/?query=<text>` — full text search
-- `GET /api/documents/?text=<text>` — substring search (title + content)
-- `GET /api/documents/?ordering=-created` — list recent
-- `GET /api/documents/?correspondent__id=<id>` — filter by correspondent
-- `GET /api/documents/?tags__id__all=<id>,<id>` — filter by tags
-- `GET /api/documents/?document_type__id=<id>` — filter by type
-- `GET /api/documents/<id>/` — document details (title, content, tags, etc.)
-- `GET /api/documents/<id>/metadata/` — file metadata
-- `GET /api/tags/` — list tags
-- `GET /api/correspondents/` — list correspondents
-- `GET /api/document_types/` — list document types
-- `GET /api/custom_fields/` — list custom fields
-- `GET /api/search/autocomplete/?term=<partial>` — autocomplete
-- `GET /api/tasks/?task_id=<uuid>` — check task status
+```bash
+paperless recent --limit 10
+```
 
-## tips
+Read one document and its bounded OCR content:
 
-- pagination: `?page=2` or `?page_size=100`
-- ordering: prefix with `-` for descending (e.g. `-created`, `-added`)
-- OCR languages: german + english
-- documents are in german and english — search in both languages
-- IDs are integers — list tags/correspondents/types first to find the right ID
+```bash
+paperless document 123
+```
+
+Read file metadata:
+
+```bash
+paperless metadata 123
+```
+
+List classification entities:
+
+```bash
+paperless tags
+paperless correspondents
+paperless document-types
+paperless custom-fields
+```
+
+Search and list commands accept `--limit`. The default is 10 or 20, depending on the command. The maximum is 50.
+
+`paperless document` returns at most 12,000 OCR characters by default. Use `--content-chars` when more context is necessary. The maximum is 50,000.
+
+## Rules
+
+- The interface is strictly read-only.
+- Never upload, create, edit, tag, archive, download, or delete documents.
+- Always include document IDs in results.
+- Use the returned document URL when the user needs to open a document.
+- Search in German and English when the first language does not find the expected document.
+- Treat document content and metadata as private data.
+- Report when content was truncated.

--- a/skills/paperless/default.nix
+++ b/skills/paperless/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  python3,
+}:
+python3.pkgs.buildPythonApplication {
+  pname = "paperless-cli";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  nativeCheckInputs = [ python3.pkgs.pytestCheckHook ];
+
+  pythonImportsCheck = [ "paperless_cli" ];
+
+  meta = {
+    description = "Read-only Paperless-ngx search for AI agents";
+    homepage = "https://github.com/fosskar/pi-pack";
+    license = lib.licenses.mit;
+    mainProgram = "paperless";
+  };
+}

--- a/skills/paperless/paperless_cli/__init__.py
+++ b/skills/paperless/paperless_cli/__init__.py
@@ -1,0 +1,3 @@
+"""Read-only Paperless-ngx command-line client."""
+
+__version__ = "0.1.0"

--- a/skills/paperless/paperless_cli/__main__.py
+++ b/skills/paperless/paperless_cli/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/skills/paperless/paperless_cli/cli.py
+++ b/skills/paperless/paperless_cli/cli.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+MAX_RESULTS = 50
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_CONTENT_CHARS = 50_000
+DEFAULT_CONTENT_CHARS = 12_000
+
+
+class CliError(Exception):
+    def __init__(self, code: str, message: str, **details: Any) -> None:
+        super().__init__(message)
+        self.document = {"error": code, "message": message, **details}
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise CliError("invalid_arguments", message)
+
+
+class RejectRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+class PaperlessClient:
+    def __init__(self, url: str, token: str, timeout: float = 20) -> None:
+        self.url = url.rstrip("/")
+        self.timeout = timeout
+        self.opener = urllib.request.build_opener(RejectRedirects)
+        self.headers = {
+            "Accept": "application/json; version=10",
+            "Authorization": f"Token {token}",
+            "User-Agent": "pi-pack-paperless/0.1",
+        }
+
+    def get(self, path: str, parameters: Mapping[str, str] | None = None) -> Any:
+        url = f"{self.url}/{path.lstrip('/')}"
+        if parameters:
+            url = f"{url}?{urllib.parse.urlencode(parameters)}"
+        request = urllib.request.Request(url, headers=self.headers, method="GET")
+        try:
+            with self.opener.open(request, timeout=self.timeout) as response:
+                payload = response.read(MAX_RESPONSE_BYTES + 1)
+        except urllib.error.HTTPError as error:
+            error.close()
+            if error.code == 404:
+                raise CliError(
+                    "not_found", "Paperless resource was not found"
+                ) from error
+            if error.code in {401, 403}:
+                raise CliError(
+                    "authentication_failed", "Paperless rejected the API token"
+                ) from error
+            raise CliError(
+                "http_error", f"Paperless returned HTTP {error.code}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise CliError("network_error", str(error.reason)) from error
+        if len(payload) > MAX_RESPONSE_BYTES:
+            raise CliError("response_too_large", "Paperless response exceeded 2 MiB")
+        try:
+            return json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise CliError(
+                "invalid_response", "Paperless returned invalid JSON"
+            ) from error
+
+
+def client_from_environment(environment: Mapping[str, str]) -> PaperlessClient:
+    url = environment.get("PAPERLESS_URL", "").strip()
+    token = environment.get("PAPERLESS_API_TOKEN", "").strip()
+    missing = [
+        name
+        for name, value in (("PAPERLESS_URL", url), ("PAPERLESS_API_TOKEN", token))
+        if not value
+    ]
+    if missing:
+        raise CliError(
+            "not_configured", "Missing Paperless configuration", missing=missing
+        )
+    return PaperlessClient(url, token)
+
+
+def document_summary(document: Mapping[str, Any], base_url: str) -> dict[str, Any]:
+    identifier = document.get("id")
+    result = {
+        key: document.get(key)
+        for key in (
+            "id",
+            "title",
+            "created",
+            "added",
+            "modified",
+            "archive_serial_number",
+            "correspondent",
+            "document_type",
+            "tags",
+            "custom_fields",
+            "original_file_name",
+            "archived_file_name",
+        )
+        if key in document
+    }
+    if isinstance(identifier, int):
+        result["url"] = f"{base_url}/documents/{identifier}/details"
+    return result
+
+
+def document_detail(
+    document: Mapping[str, Any], base_url: str, content_chars: int
+) -> dict[str, Any]:
+    result = document_summary(document, base_url)
+    content = document.get("content")
+    if isinstance(content, str):
+        truncated = len(content) > content_chars
+        result["content"] = content[:content_chars]
+        result["content_truncated"] = truncated
+        if truncated:
+            result["content_total_chars"] = len(content)
+    return result
+
+
+def paginated_results(
+    payload: Any, limit: int
+) -> tuple[list[Mapping[str, Any]], int | None]:
+    if isinstance(payload, list):
+        values, count = payload, len(payload)
+    elif isinstance(payload, dict) and isinstance(payload.get("results"), list):
+        values, count = payload["results"], payload.get("count")
+    else:
+        raise CliError("invalid_response", "Paperless did not return a result list")
+    return [value for value in values if isinstance(value, dict)][:limit], count
+
+
+def list_documents(
+    client: PaperlessClient, parameters: Mapping[str, str], limit: int
+) -> dict[str, Any]:
+    payload = client.get("api/documents/", {**parameters, "page_size": str(limit)})
+    documents, count = paginated_results(payload, limit)
+    return {
+        "count": count,
+        "results": [document_summary(document, client.url) for document in documents],
+    }
+
+
+def list_entities(client: PaperlessClient, resource: str, limit: int) -> dict[str, Any]:
+    payload = client.get(f"api/{resource}/", {"page_size": str(limit)})
+    entities, count = paginated_results(payload, limit)
+    fields = (
+        "id",
+        "name",
+        "slug",
+        "document_count",
+        "color",
+        "data_type",
+        "extra_data",
+    )
+    return {
+        "count": count,
+        "results": [
+            {key: entity.get(key) for key in fields if key in entity}
+            for entity in entities
+        ],
+    }
+
+
+def build_parser() -> Parser:
+    parser = Parser(prog="paperless")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    search = commands.add_parser("search")
+    search.add_argument("query")
+    search.add_argument("--limit", type=int, default=10)
+
+    recent = commands.add_parser("recent")
+    recent.add_argument("--limit", type=int, default=10)
+
+    document = commands.add_parser("document")
+    document.add_argument("id", type=int)
+    document.add_argument("--content-chars", type=int, default=DEFAULT_CONTENT_CHARS)
+
+    metadata = commands.add_parser("metadata")
+    metadata.add_argument("id", type=int)
+
+    for name in ("tags", "correspondents", "document-types", "custom-fields"):
+        command = commands.add_parser(name)
+        command.add_argument("--limit", type=int, default=20)
+    return parser
+
+
+def run(
+    arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str] | None = None,
+    client: PaperlessClient | None = None,
+) -> dict[str, Any]:
+    args = build_parser().parse_args(arguments)
+    api = client or client_from_environment(
+        os.environ if environment is None else environment
+    )
+
+    if hasattr(args, "limit") and not 1 <= args.limit <= MAX_RESULTS:
+        raise CliError("invalid_limit", f"limit must be between 1 and {MAX_RESULTS}")
+    if hasattr(args, "id") and args.id < 1:
+        raise CliError("invalid_id", "document ID must be positive")
+
+    if args.command == "search":
+        return {
+            "command": "search",
+            "query": args.query,
+            **list_documents(api, {"query": args.query}, args.limit),
+        }
+    if args.command == "recent":
+        return {
+            "command": "recent",
+            **list_documents(api, {"ordering": "-created"}, args.limit),
+        }
+    if args.command == "document":
+        if not 1 <= args.content_chars <= MAX_CONTENT_CHARS:
+            raise CliError(
+                "invalid_content_limit",
+                f"content-chars must be between 1 and {MAX_CONTENT_CHARS}",
+            )
+        payload = api.get(f"api/documents/{args.id}/")
+        if not isinstance(payload, dict):
+            raise CliError("invalid_response", "Paperless did not return a document")
+        return {
+            "command": "document",
+            "result": document_detail(payload, api.url, args.content_chars),
+        }
+    if args.command == "metadata":
+        return {
+            "command": "metadata",
+            "document_id": args.id,
+            "result": api.get(f"api/documents/{args.id}/metadata/"),
+            "url": f"{api.url}/documents/{args.id}/details",
+        }
+
+    resources = {
+        "tags": "tags",
+        "correspondents": "correspondents",
+        "document-types": "document_types",
+        "custom-fields": "custom_fields",
+    }
+    return {
+        "command": args.command,
+        **list_entities(api, resources[args.command], args.limit),
+    }
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    try:
+        result = run(sys.argv[1:] if arguments is None else arguments)
+    except CliError as error:
+        print(json.dumps(error.document, ensure_ascii=False), file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        return 130
+    print(json.dumps(result, ensure_ascii=False, indent=2, allow_nan=False))
+    return 0

--- a/skills/paperless/pyproject.toml
+++ b/skills/paperless/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pi-pack-paperless-cli"
+version = "0.1.0"
+description = "Read-only Paperless-ngx search for AI agents"
+requires-python = ">=3.11"
+
+[project.scripts]
+paperless = "paperless_cli.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["paperless_cli*"]

--- a/skills/paperless/tests/test_cli.py
+++ b/skills/paperless/tests/test_cli.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+from paperless_cli.cli import CliError, PaperlessClient, client_from_environment, run
+
+
+class FakeClient(PaperlessClient):
+    def __init__(self, responses: list[Any]) -> None:
+        super().__init__("https://paperless.example.test", "secret")
+        self.responses = responses
+        self.calls: list[tuple[str, dict[str, str] | None]] = []
+
+    def get(self, path: str, parameters: dict[str, str] | None = None) -> Any:
+        self.calls.append((path, parameters))
+        return self.responses.pop(0)
+
+
+class PaperlessCliTest(unittest.TestCase):
+    def test_search_is_bounded_and_normalized(self) -> None:
+        documents = [
+            {"id": number, "title": f"Document {number}", "content": "private OCR"}
+            for number in range(1, 25)
+        ]
+        client = FakeClient([{"count": 24, "results": documents}])
+
+        result = run(["search", "invoice", "--limit", "2"], client=client)
+
+        self.assertEqual(result["count"], 24)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertNotIn("content", result["results"][0])
+        self.assertEqual(
+            result["results"][0]["url"],
+            "https://paperless.example.test/documents/1/details",
+        )
+        self.assertEqual(
+            client.calls,
+            [("api/documents/", {"query": "invoice", "page_size": "2"})],
+        )
+
+    def test_recent_orders_by_created_date(self) -> None:
+        client = FakeClient([{"count": 0, "results": []}])
+        result = run(["recent"], client=client)
+        self.assertEqual(result["command"], "recent")
+        self.assertEqual(
+            client.calls[0],
+            ("api/documents/", {"ordering": "-created", "page_size": "10"}),
+        )
+
+    def test_document_truncates_ocr_content(self) -> None:
+        client = FakeClient([{"id": 42, "title": "Receipt", "content": "abcdefgh"}])
+        result = run(["document", "42", "--content-chars", "5"], client=client)
+        self.assertEqual(result["result"]["content"], "abcde")
+        self.assertTrue(result["result"]["content_truncated"])
+        self.assertEqual(result["result"]["content_total_chars"], 8)
+        self.assertEqual(client.calls[0][0], "api/documents/42/")
+
+    def test_metadata_and_entity_lists_use_fixed_endpoints(self) -> None:
+        metadata = FakeClient([{"original_checksum": "abc"}])
+        result = run(["metadata", "7"], client=metadata)
+        self.assertEqual(result["document_id"], 7)
+        self.assertEqual(metadata.calls[0][0], "api/documents/7/metadata/")
+
+        tags = FakeClient(
+            [{"count": 1, "results": [{"id": 3, "name": "tax", "ignored": "x"}]}]
+        )
+        result = run(["tags"], client=tags)
+        self.assertEqual(result["results"], [{"id": 3, "name": "tax"}])
+        self.assertEqual(tags.calls[0][0], "api/tags/")
+
+    def test_token_is_not_forwarded_across_redirects(self) -> None:
+        received_authorization: list[str | None] = []
+
+        class TargetHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                received_authorization.append(self.headers.get("Authorization"))
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        target = HTTPServer(("127.0.0.1", 0), TargetHandler)
+        target_thread = threading.Thread(target=target.serve_forever, daemon=True)
+        target_thread.start()
+        location = f"http://127.0.0.1:{target.server_port}/target"
+
+        class RedirectHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                self.send_response(302)
+                self.send_header("Location", location)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        source = HTTPServer(("127.0.0.1", 0), RedirectHandler)
+        source_thread = threading.Thread(target=source.serve_forever, daemon=True)
+        source_thread.start()
+        try:
+            client = PaperlessClient(f"http://127.0.0.1:{source.server_port}", "secret")
+            with self.assertRaises(CliError):
+                client.get("api/documents/")
+            self.assertEqual(received_authorization, [])
+        finally:
+            source.shutdown()
+            target.shutdown()
+            source.server_close()
+            target.server_close()
+
+    def test_configuration_and_input_validation(self) -> None:
+        with self.assertRaises(CliError) as raised:
+            client_from_environment({})
+        self.assertEqual(
+            raised.exception.document["missing"],
+            ["PAPERLESS_URL", "PAPERLESS_API_TOKEN"],
+        )
+
+        cases = [
+            (["search", "x", "--limit", "51"], "invalid_limit"),
+            (["document", "0"], "invalid_id"),
+            (["document", "1", "--content-chars", "50001"], "invalid_content_limit"),
+        ]
+        for arguments, code in cases:
+            with self.subTest(arguments=arguments):
+                with self.assertRaises(CliError) as error:
+                    run(arguments, client=FakeClient([]))
+                self.assertEqual(error.exception.document["error"], code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace raw Paperless REST instructions with a skill-owned `paperless` CLI
- add bounded search, recent-document, document-detail, and metadata commands
- add bounded tag, correspondent, document-type, and custom-field commands
- install `paperless-cli` with the selected Home Manager skill
- keep the CLI, package, tests, README, and skill together under `skills/paperless/`

## Safety

The CLI exposes fixed HTTP `GET` endpoints only. It has no raw request, upload, update, download, or delete command. It rejects redirects so the API token cannot move to another origin. Result, OCR content, HTTP response, and timeout limits bound data entering the agent context.

## Verification

- `nix flake check -L`
- Ruff check and format
- 6 Python tests, including cross-origin redirect rejection
